### PR TITLE
Add support for io.wcm.testing.mock.aem.MockTag#getLocalizedTitlePaths()

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="5.3.0" date="not released">
+      <action type="add" dev="catalinadumitruu" issue="9">
+        Implement MockTag.getLocalizedTitlePaths method.
+      </action>
       <action type="add" dev="rubnig" issue="16">
         Add mock implementation for JcrTagManagerFactory.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="add" dev="royteeuwen" issue="4">
         Implement all mock methods that were added since AEM 6.5.6+ for LanguageManager.
       </action>
+      <action type="add" dev="catalinadumitruu" issue="8">
+        Implement MockTag.getTitlePath methods.
+      </action>
       <action type="update" dev="sseifert">
         Update to latest JCR Mock, OSGi Mock, Sling Mock.
       </action>

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
@@ -372,15 +372,35 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
     return titlePath.toString();
   }
 
+  @Override
+  public Map<Locale, String> getLocalizedTitlePaths() {
+    Tag parent = this.getParent();
+    Map<Locale, String> map = parent != null ? parent.getLocalizedTitlePaths() : new HashMap<>();
+
+    for (Map.Entry<Locale, String> entry : map.entrySet()) {
+      if (parent.isNamespace()) {
+        entry.setValue(entry.getValue() + TITLEPATH_NS_DELIMITER + getTitle(entry.getKey()));
+      } else {
+        entry.setValue(entry.getValue() + TITLEPATH_DELIMITER + getTitle(entry.getKey()));
+      }
+    }
+
+    Map<Locale, String> localMap = getLocalizedTitles();
+    for (Map.Entry<Locale, String> entry : localMap.entrySet()) {
+      if (parent == null) {
+        map.put(entry.getKey(), entry.getValue());
+      } else if (!map.containsKey(entry.getKey())) {
+        map.put(entry.getKey(), parent.getTitlePath(entry.getKey()) + TITLEPATH_DELIMITER + entry.getValue());
+      }
+    }
+
+    return map;
+  }
+
   // --- unsupported operations ---
 
   @Override
   public String getGQLSearchExpression(String arg0) {
-    throw new UnsupportedOperationException("Unsupported operation");
-  }
-
-  @Override
-  public Map<Locale, String> getLocalizedTitlePaths() {
     throw new UnsupportedOperationException("Unsupported operation");
   }
 

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
@@ -333,20 +333,8 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
   private static String escapeTitle(String title) {
     return StringUtils.replace(StringUtils.replace(title, SEPARATOR, " "), NAMESPACE_DELIMITER, " ");
   }
-
-  // --- unsupported operations ---
-
-  @Override
-  public String getGQLSearchExpression(String arg0) {
-    throw new UnsupportedOperationException("Unsupported operation");
-  }
-
-  @Override
-  public Map<Locale, String> getLocalizedTitlePaths() {
-    throw new UnsupportedOperationException("Unsupported operation");
-  }
-
-  @Override
+  
+    @Override
   public String getTitlePath() {
     return getTitlePath(null);
   }
@@ -379,6 +367,18 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
     }
 
     return titlePath.toString();
+  }
+
+  // --- unsupported operations ---
+
+  @Override
+  public String getGQLSearchExpression(String arg0) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public Map<Locale, String> getLocalizedTitlePaths() {
+    throw new UnsupportedOperationException("Unsupported operation");
   }
 
   private String extractPathPart(final String property, final BinaryOperator<String> pathPartExtractor, final String defaultValue) {

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
@@ -19,8 +19,11 @@
  */
 package io.wcm.testing.mock.aem;
 
+import static com.day.cq.tagging.TagConstants.DEFAULT_NAMESPACE;
 import static com.day.cq.tagging.TagConstants.NAMESPACE_DELIMITER;
 import static com.day.cq.tagging.TagConstants.SEPARATOR;
+import static com.day.cq.tagging.TagConstants.TITLEPATH_DELIMITER;
+import static com.day.cq.tagging.TagConstants.TITLEPATH_NS_DELIMITER;
 
 import java.util.Calendar;
 import java.util.Collection;
@@ -333,22 +336,22 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
   private static String escapeTitle(String title) {
     return StringUtils.replace(StringUtils.replace(title, SEPARATOR, " "), NAMESPACE_DELIMITER, " ");
   }
-  
-    @Override
+
+  @Override
   public String getTitlePath() {
     return getTitlePath(null);
   }
 
   @Override
-  public String getTitlePath(Locale arg0) {
-    StringBuffer titlePath = new StringBuffer();
+  public String getTitlePath(Locale locale) {
+    StringBuilder titlePath = new StringBuilder();
     Tag ancestor = this;
 
-    while(ancestor != null) {
+    while (ancestor != null) {
       Tag parent = ancestor.getParent();
-      if(ancestor != this) {
-        if(parent == null) {
-          if(DEFAULT_NAMESPACE.equals(ancestor.getName())) {
+      if (ancestor != this) {
+        if (parent == null) {
+          if (DEFAULT_NAMESPACE.equals(ancestor.getName())) {
             break;
           }
           titlePath.insert(0, TITLEPATH_NS_DELIMITER);
@@ -357,7 +360,7 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
         }
       }
       String title = ancestor.getTitle();
-      if(title != null) {
+      if (title != null) {
         titlePath.insert(0, title);
       } else {
         titlePath.insert(0, ancestor.getName());

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockTag.java
@@ -348,12 +348,37 @@ class MockTag extends SlingAdaptable implements Tag, Comparable<Tag> {
 
   @Override
   public String getTitlePath() {
-    throw new UnsupportedOperationException("Unsupported operation");
+    return getTitlePath(null);
   }
 
   @Override
   public String getTitlePath(Locale arg0) {
-    throw new UnsupportedOperationException("Unsupported operation");
+    StringBuffer titlePath = new StringBuffer();
+    Tag ancestor = this;
+
+    while(ancestor != null) {
+      Tag parent = ancestor.getParent();
+      if(ancestor != this) {
+        if(parent == null) {
+          if(DEFAULT_NAMESPACE.equals(ancestor.getName())) {
+            break;
+          }
+          titlePath.insert(0, TITLEPATH_NS_DELIMITER);
+        } else {
+          titlePath.insert(0, TITLEPATH_DELIMITER);
+        }
+      }
+      String title = ancestor.getTitle();
+      if(title != null) {
+        titlePath.insert(0, title);
+      } else {
+        titlePath.insert(0, ancestor.getName());
+      }
+
+      ancestor = parent;
+    }
+
+    return titlePath.toString();
   }
 
   private String extractPathPart(final String property, final BinaryOperator<String> pathPartExtractor, final String defaultValue) {

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
@@ -295,6 +295,19 @@ public class MockTagTest {
     assertTagExpression(tag, "tag3", "default/tag3");
   }
 
+  @Test
+  public void getLocalizedTitlePaths() {
+    Map<Locale,String> localizedTitlePaths = aemApi.getLocalizedTitlePaths();
+
+    assertNotNull(localizedTitlePaths);
+    assertEquals(6, localizedTitlePaths.size());
+    assertEquals("WCM IO Tag Namespace : AEM / English AEM API", localizedTitlePaths.get(Locale.ENGLISH));
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API for US", localizedTitlePaths.get(Locale.US));
+    assertEquals("WCM IO Tag Namespace : AEM / German AEM API", localizedTitlePaths.get(Locale.GERMAN));
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API for Germany", localizedTitlePaths.get(Locale.GERMANY));
+    assertEquals("WCM IO Tag Namespace : AEM / Portuguese (Brazil) AEM API/:with special chars", localizedTitlePaths.get(LOCALE_PT_BR));
+  }
+
   private void assertTagExpression(@NotNull final Tag tag,
                                    @NotNull final String tagId,
                                    @NotNull final String tagPath) {

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
@@ -209,6 +209,17 @@ public class MockTagTest {
     assertEquals("English AEM API", aemApi.getTitle(Locale.ENGLISH));
     assertEquals("AEM API for US", aemApi.getTitle(Locale.US));
   }
+  
+    @Test
+  public void testTitlePath() {
+    assertEquals("wcmio: AEM", aem.getTitlePath());
+    assertEquals("wcmio: AEM", aem.getTitlePath(Locale.ENGLISH));
+    assertEquals("wcmio: AEM", aem.getTitlePath(Locale.US));
+
+    assertEquals("wcmio: AEM / AEM/API", aemApi.getTitlePath());
+    assertEquals("wcmio: AEM / English AEM API", aemApi.getTitlePath(Locale.ENGLISH));
+    assertEquals("wcmio: AEM / AEM API for US", aemApi.getTitlePath(Locale.US));
+  }
 
   @Test
   public void testLastModified() {

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
@@ -218,7 +218,7 @@ public class MockTagTest {
 
     assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath());
     assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath(Locale.ENGLISH));
-    assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath(Locale.US));
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath(Locale.US)); 
   }
 
   @Test

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockTagTest.java
@@ -210,15 +210,15 @@ public class MockTagTest {
     assertEquals("AEM API for US", aemApi.getTitle(Locale.US));
   }
   
-    @Test
+  @Test
   public void testTitlePath() {
-    assertEquals("wcmio: AEM", aem.getTitlePath());
-    assertEquals("wcmio: AEM", aem.getTitlePath(Locale.ENGLISH));
-    assertEquals("wcmio: AEM", aem.getTitlePath(Locale.US));
+    assertEquals("WCM IO Tag Namespace : AEM", aem.getTitlePath());
+    assertEquals("WCM IO Tag Namespace : AEM", aem.getTitlePath(Locale.ENGLISH));
+    assertEquals("WCM IO Tag Namespace : AEM", aem.getTitlePath(Locale.US));
 
-    assertEquals("wcmio: AEM / AEM/API", aemApi.getTitlePath());
-    assertEquals("wcmio: AEM / English AEM API", aemApi.getTitlePath(Locale.ENGLISH));
-    assertEquals("wcmio: AEM / AEM API for US", aemApi.getTitlePath(Locale.US));
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath());
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath(Locale.ENGLISH));
+    assertEquals("WCM IO Tag Namespace : AEM / AEM API", aemApi.getTitlePath(Locale.US));
   }
 
   @Test


### PR DESCRIPTION
Add support for io.wcm.testing.mock.aem.MockTag#getLocalizedTitlePaths().

Solves: https://github.com/wcm-io/io.wcm.testing.aem-mock/issues/19