### PR TITLE
Resource Resolver Factory Activator: Provide old or new name for vanity paths allow/denylists by auto-detecting by auto-detecting form classpath

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update to latest Sling Mock.
       </action>
+      <action type="update" dev="sseifert">
+        Resource Resolver Factory Activator: Provide old or new name for vanity paths allow/denylists by auto-detecting by auto-detecting form classpath (related to SLING-11742).
+      </action>
     </release>
 
     <release version="5.3.0" date="2023-08-21">

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -19,7 +19,6 @@
  */
 package io.wcm.testing.mock.aem.context;
 
-import io.wcm.testing.mock.aem.MockJcrTagManagerFactory;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +45,7 @@ import io.wcm.testing.mock.aem.MockAemAdapterFactory;
 import io.wcm.testing.mock.aem.MockComponentContext;
 import io.wcm.testing.mock.aem.MockContentPolicyStorage;
 import io.wcm.testing.mock.aem.MockExternalizer;
+import io.wcm.testing.mock.aem.MockJcrTagManagerFactory;
 import io.wcm.testing.mock.aem.MockLanguageManager;
 import io.wcm.testing.mock.aem.MockLayerAdapterFactory;
 import io.wcm.testing.mock.aem.MockPageManagerFactory;
@@ -140,12 +140,12 @@ public class AemContextImpl extends SlingContextImpl {
     props.put("resource.resolver.vanitypath.maxEntries", -1);
     props.put("resource.resolver.vanitypath.bloomfilter.maxBytes", 1024000);
     props.put("resource.resolver.optimize.alias.resolution", false);
-    props.put("resource.resolver.vanitypath.whitelist", new String[] {
+    props.put(ResourceResolverFactoryConfigPropertyNames.getVanityPathAllowListPropertyName(), new String[] {
         "/apps/",
         "/libs/",
         "/content/"
     });
-    props.put("resource.resolver.vanitypath.blacklist", new String[] {
+    props.put(ResourceResolverFactoryConfigPropertyNames.getVanityPathDenyListPropertyName(), new String[] {
         "/content/usergenerated"
     });
     props.put("resource.resolver.vanity.precedence", false);

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/ResourceResolverFactoryConfigPropertyNames.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/ResourceResolverFactoryConfigPropertyNames.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.testing.mock.aem.context;
 
+import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,7 +43,7 @@ final class ResourceResolverFactoryConfigPropertyNames {
     try {
       Class<?> resourceResolverFactoryConfigClass = Class.forName(ResourceResolverFactoryConfig.class.getName());
       Set<String> methodNames = Stream.of(resourceResolverFactoryConfigClass.getDeclaredMethods())
-          .map(method -> method.getName())
+          .map(Method::getName)
           .collect(Collectors.toSet());
       // use new names as fields do exist
       if (methodNames.contains("resource_resolver_vanitypath_allowlist")

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/ResourceResolverFactoryConfigPropertyNames.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/ResourceResolverFactoryConfigPropertyNames.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2023 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.testing.mock.aem.context;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.sling.resourceresolver.impl.ResourceResolverFactoryConfig;
+
+/**
+ * The names of the vanity path allow/denylist configuration property changed between releases (SLING-11742).
+ * Auto-detect the correct name for the resource resolver in current classpath.
+ */
+final class ResourceResolverFactoryConfigPropertyNames {
+
+  private static final String VANITY_PATH_ALLOW_LIST_PROPERTY_NAME;
+  private static final String VANITY_PATH_DENY_LIST_PROPERTY_NAME;
+
+  static {
+    // old names as fallback
+    String vanityPathAllowListPropertyName = "resource.resolver.vanitypath.whitelist";
+    String vanityPathDenyListPropertyName = "resource.resolver.vanitypath.blacklist";
+
+    try {
+      Class<?> resourceResolverFactoryConfigClass = Class.forName(ResourceResolverFactoryConfig.class.getName());
+      Set<String> methodNames = Stream.of(resourceResolverFactoryConfigClass.getDeclaredMethods())
+          .map(method -> method.getName())
+          .collect(Collectors.toSet());
+      // use new names as fields do exist
+      if (methodNames.contains("resource_resolver_vanitypath_allowlist")
+          && methodNames.contains("resource_resolver_vanitypath_denylist")) {
+        vanityPathAllowListPropertyName = "resource.resolver.vanitypath.allowlist";
+        vanityPathDenyListPropertyName = "resource.resolver.vanitypath.denylist";
+      }
+    }
+    catch (ClassNotFoundException ex) {
+      // ignore, keep old names
+    }
+
+    VANITY_PATH_ALLOW_LIST_PROPERTY_NAME = vanityPathAllowListPropertyName;
+    VANITY_PATH_DENY_LIST_PROPERTY_NAME = vanityPathDenyListPropertyName;
+  }
+
+  static String getVanityPathAllowListPropertyName() {
+    return VANITY_PATH_ALLOW_LIST_PROPERTY_NAME;
+  }
+
+  static String getVanityPathDenyListPropertyName() {
+    return VANITY_PATH_DENY_LIST_PROPERTY_NAME;
+  }
+
+  private ResourceResolverFactoryConfigPropertyNames() {
+    // static methods only
+  }
+
+}


### PR DESCRIPTION
related to [SLING-11742](https://issues.apache.org/jira/browse/SLING-11742)