### PR TITLE
Do not disable optimized Sling Alias resolution by default

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update to latest Sling Mock.
       </action>
+      <action type="update" dev="sseifert">
+        Resource Resolver Factory: Switch back to resource.resolver.optimize.alias.resolution=true to avoid warning.
+      </action>
     </release>
 
     <release version="5.4.2" date="2023-11-20">

--- a/changes.xml
+++ b/changes.xml
@@ -27,8 +27,8 @@
       <action type="update" dev="sseifert">
         Update to latest Sling Mock.
       </action>
-      <action type="update" dev="sseifert">
-        Resource Resolver Factory: Switch back to resource.resolver.optimize.alias.resolution=true to avoid warning.
+      <action type="update" dev="sseifert" issue="29">
+        Resource Resolver Factory: Switch back to resource.resolver.optimize.alias.resolution=true (which is default) to avoid warning.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,8 @@
         Update to latest Sling Mock.
       </action>
       <action type="update" dev="sseifert" issue="29">
-        Resource Resolver Factory: Switch back to resource.resolver.optimize.alias.resolution=true (which is default) to avoid warning.
+        Resource Resolver Factory: Set resource.resolver.optimize.alias.resolution=true and resource.resolver.enable.vanitypath=true to use the optimized sling:alias resolution.
+        As a result, sling:alias resolution is only supported with JCR_OAK resource resolver type.
       </action>
     </release>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -287,6 +287,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import io.wcm.testing.mock.aem.xf.MockExperienceFragmentAdapterFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -57,6 +56,7 @@ import io.wcm.testing.mock.aem.dam.MockAssetHandler;
 import io.wcm.testing.mock.aem.dam.MockAssetStore;
 import io.wcm.testing.mock.aem.dam.MockPublishUtils;
 import io.wcm.testing.mock.aem.granite.MockResourceCollectionManager;
+import io.wcm.testing.mock.aem.xf.MockExperienceFragmentAdapterFactory;
 
 /**
  * Defines AEM context objects with lazy initialization.
@@ -141,7 +141,6 @@ public class AemContextImpl extends SlingContextImpl {
     props.put("resource.resolver.enable.vanitypath", false);
     props.put("resource.resolver.vanitypath.maxEntries", -1);
     props.put("resource.resolver.vanitypath.bloomfilter.maxBytes", 1024000);
-    props.put("resource.resolver.optimize.alias.resolution", false);
     props.put(ResourceResolverFactoryConfigPropertyNames.getVanityPathAllowListPropertyName(), new String[] {
         "/apps/",
         "/libs/",

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -138,7 +138,6 @@ public class AemContextImpl extends SlingContextImpl {
     });
     props.put("resource.resolver.map.location", "/etc/map");
     props.put("resource.resolver.default.vanity.redirect.status", "302");
-    props.put("resource.resolver.enable.vanitypath", false);
     props.put("resource.resolver.vanitypath.maxEntries", -1);
     props.put("resource.resolver.vanitypath.bloomfilter.maxBytes", 1024000);
     props.put(ResourceResolverFactoryConfigPropertyNames.getVanityPathAllowListPropertyName(), new String[] {

--- a/core/src/test/java/io/wcm/testing/mock/aem/context/AemContextImplTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/context/AemContextImplTest.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.testing.mock.aem.context;
 
-import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
-import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -28,7 +26,6 @@ import static org.junit.Assert.assertNull;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
 import org.junit.After;
 import org.junit.Before;
@@ -138,19 +135,6 @@ public class AemContextImplTest {
     context.currentResource(context.resourceResolver().getResource(contentRoot + "/toolbar/jcr:content"));
     assertEquals(contentRoot + "/toolbar", context.currentPage().getPath());
     assertEquals(contentRoot + "/toolbar/jcr:content", context.currentResource().getPath());
-  }
-
-  @Test
-  public void testSlingAlias() {
-    if (context.resourceResolverType() == ResourceResolverType.RESOURCERESOLVER_MOCK) {
-      // sling:alias is not supported for RESOURCERESOLVER_MOCK
-      return;
-    }
-    Resource resource = context.create().resource(contentRoot + "/myresource",
-        JCR_PRIMARYTYPE, NT_UNSTRUCTURED,
-        "sling:alias", "myalias");
-    assertEquals(contentRoot + "/myresource", resource.getPath());
-    assertEquals(contentRoot + "/myalias", context.resourceResolver().map(resource.getPath()));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/context/AemContextImpl_SlingAliasTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/context/AemContextImpl_SlingAliasTest.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2023 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.testing.mock.aem.context;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+public class AemContextImpl_SlingAliasTest {
+
+  @Rule
+  public AemContext context = TestAemContext.newAemContextBuilder()
+      .resourceResolverFactoryActivatorProps(Map.of("resource.resolver.optimize.alias.resolution", false))
+      .build();
+
+  private String contentRoot;
+
+  @Before
+  public void setUp() throws Exception {
+    contentRoot = context.uniqueRoot().content() + "/sample";
+  }
+
+  @Test
+  public void testSlingAlias() {
+    if (context.resourceResolverType() == ResourceResolverType.RESOURCERESOLVER_MOCK) {
+      // sling:alias is not supported for RESOURCERESOLVER_MOCK
+      return;
+    }
+    Resource resource = context.create().resource(contentRoot + "/myresource",
+        JCR_PRIMARYTYPE, NT_UNSTRUCTURED,
+        "sling:alias", "myalias");
+    assertEquals(contentRoot + "/myresource", resource.getPath());
+    assertEquals(contentRoot + "/myalias", context.resourceResolver().map(resource.getPath()));
+  }
+
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/context/SlingAlias_JcrOakTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/context/SlingAlias_JcrOakTest.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2023 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.testing.mock.aem.context;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
+import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+public class SlingAlias_JcrOakTest {
+
+  @Rule
+  public AemContext context = new AemContext(ResourceResolverType.JCR_OAK);
+
+  private String contentRoot;
+
+  @Before
+  public void setUp() throws Exception {
+    contentRoot = context.uniqueRoot().content() + "/sample";
+  }
+
+  @Test
+  public void testSlingAlias() throws PersistenceException {
+    Resource resource = context.create().resource(contentRoot + "/myresource",
+        JCR_PRIMARYTYPE, NT_UNSTRUCTURED,
+        "sling:alias", "myalias");
+    context.resourceResolver().commit();
+
+    assertEquals(contentRoot + "/myresource", resource.getPath());
+    assertEquals(contentRoot + "/myalias", context.resourceResolver().map(resource.getPath()));
+  }
+
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/context/SlingAlias_JcrOakTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/context/SlingAlias_JcrOakTest.java
@@ -21,8 +21,11 @@ package io.wcm.testing.mock.aem.context;
 
 import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
 import static com.day.cq.commons.jcr.JcrConstants.NT_UNSTRUCTURED;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -52,7 +55,10 @@ public class SlingAlias_JcrOakTest {
     context.resourceResolver().commit();
 
     assertEquals(contentRoot + "/myresource", resource.getPath());
-    assertEquals(contentRoot + "/myalias", context.resourceResolver().map(resource.getPath()));
+
+    // alias processing happens asynchronously, so it may take a bit until the alias resolution works
+    await().atMost(2, SECONDS).until(() -> StringUtils.equals(contentRoot + "/myalias",
+        context.resourceResolver().map(resource.getPath())));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/context/TestAemContext.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/context/TestAemContext.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit.AemContextBuilder;
 import io.wcm.testing.mock.aem.junit.AemContextCallback;
 
 public final class TestAemContext {
@@ -57,6 +58,15 @@ public final class TestAemContext {
 
   public static @NotNull AemContext newAemContext(ResourceResolverType... resourceResolverTypes) {
     return new AemContext(new SetUpCallback(), resourceResolverTypes);
+  }
+
+  public static @NotNull AemContextBuilder newAemContextBuilder() {
+    return newAemContextBuilder(ALL_TYPES);
+  }
+
+  public static @NotNull AemContextBuilder newAemContextBuilder(ResourceResolverType... resourceResolverTypes) {
+    return new AemContextBuilder(resourceResolverTypes)
+        .afterSetUp(new SetUpCallback());
   }
 
   /**


### PR DESCRIPTION
Since release 4.1.4 we've set to `resource.resolver.optimize.alias.resolution=false` for the Resource Resolver Factory by default in unit tests, although this is not the Sling default. Having it enabled did/does not work with actual alias resolution in unit test context.

Starting with Sling Resource Resolver 1.11.2 a WARN is logged that this "unoptimized code path" is flawed and will be removed in a future version. So we should not disable it by default.

So, since release 5.4.4 we've enabled by default for Resource Resolver:
* `resource.resolver.optimize.alias.resolution=false`
* `resource.resolver.enable.vanitypath=true`

With this setting, sling:alias resolution is fully supported using `JCR_OAK` resource resolver type.

As a downside, sling:alias is no longer supported with `JCR_MOCK` resource resolver type, because that does not support JCR Observation events.