### PR TITLE
Make template optional

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="koenkicken" issue="36">
         MockComponent: Implement isContainer method.
       </action>
+      <action type="update" dev="alexandru-stancioiu" issue="38">
+        MockPageManager: Allow to create page without template.
+      </action>
       <action type="update" dev="sseifert" issue="33">
         Remove outdated dependency to org.apache.sling.commons.json.
       </action>

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockPageManager.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockPageManager.java
@@ -119,7 +119,9 @@ class MockPageManager extends SlingAdaptable implements PageManager {
       props = new HashMap<>();
       props.put(JCR_PRIMARYTYPE, "cq:PageContent");
       props.put(JCR_TITLE, title);
-      props.put(PN_TEMPLATE, template);
+      if (template != null) {
+        props.put(PN_TEMPLATE, template);
+      }
       Resource contentResource = this.resourceResolver.create(pageResource, JCR_CONTENT, props);
 
       // create initial content from template

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockPageManager.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockPageManager.java
@@ -125,16 +125,8 @@ class MockPageManager extends SlingAdaptable implements PageManager {
       Resource contentResource = this.resourceResolver.create(pageResource, JCR_CONTENT, props);
 
       // create initial content from template
-      Resource templateResource = resourceResolver.getResource(template);
-      if (templateResource != null) {
-        Template templateInstance = templateResource.adaptTo(Template.class);
-        if (templateInstance != null) {
-          String initialContentPath = templateInstance.getInitialContentPath();
-          Resource initialContentResource = resourceResolver.getResource(initialContentPath);
-          if (initialContentResource != null) {
-            copyContent(initialContentResource, contentResource, true);
-          }
-        }
+      if (template != null) {
+        createInitialContentFromTemplate(contentResource, template);
       }
 
       if (autoSave) {
@@ -146,6 +138,20 @@ class MockPageManager extends SlingAdaptable implements PageManager {
     }
 
     return pageResource.adaptTo(Page.class);
+  }
+
+  private void createInitialContentFromTemplate(@NotNull Resource contentResource, @NotNull String template) throws PersistenceException {
+    Resource templateResource = resourceResolver.getResource(template);
+    if (templateResource != null) {
+      Template templateInstance = templateResource.adaptTo(Template.class);
+      if (templateInstance != null) {
+        String initialContentPath = templateInstance.getInitialContentPath();
+        Resource initialContentResource = resourceResolver.getResource(initialContentPath);
+        if (initialContentResource != null) {
+          copyContent(initialContentResource, contentResource, true);
+        }
+      }
+    }
   }
 
   @SuppressFBWarnings("STYLE")

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockPageManagerTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockPageManagerTest.java
@@ -90,6 +90,12 @@ public class MockPageManagerTest {
   }
 
   @Test
+  public void testCreatePageWithNullTemplate() throws WCMException {
+    testCreatePageInternal(false, null);
+    assertTrue(this.resourceResolver.hasChanges());
+  }
+
+  @Test
   public void testCreatePageWithAutoSave() throws WCMException {
     testCreatePageInternal(true, "/apps/sample/templates/homepage");
     assertFalse(this.resourceResolver.hasChanges());


### PR DESCRIPTION
Template should be optional similar to real PageManager implementation.
This caused an inconvenience as Launches for Content Fragments do not a templatized page