### PR TITLE
Add mock impl for Adobe Granite Asset API

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,12 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="5.5.6" date="not released">
+    <release version="5.6.0" date="not released">
+      <action type="add" dev="senn" issue="49">
+        Add mock implementation of Adobe Granite Asset API.
+      </action>
       <action type="update" dev="sseifert">
         Update to latest OSGi Mock, Sling Mock.
-      </action>
-      <action type="update" dev="senn">
-        Implement Adobe Granite Asset API mocks.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update to latest OSGi Mock, Sling Mock.
       </action>
+      <action type="update" dev="senn">
+        Implement Adobe Granite Asset API mocks.
+      </action>
     </release>
 
     <release version="5.5.4" date="2024-07-18">

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -181,6 +181,17 @@ public class AemContextImpl extends SlingContextImpl {
   }
 
   /**
+   * @return Adobe Granite Asset manager
+   */
+  public @NotNull com.adobe.granite.asset.api.AssetManager graniteAssetManager() {
+    com.adobe.granite.asset.api.AssetManager assetManager = resourceResolver().adaptTo(com.adobe.granite.asset.api.AssetManager.class);
+    if (assetManager == null) {
+      throw new RuntimeException("No granite asset manager");
+    }
+    return assetManager;
+  }
+
+  /**
    * @return Content builder for building test content
    */
   @Override

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -63,6 +63,7 @@ import io.wcm.testing.mock.aem.xf.MockExperienceFragmentAdapterFactory;
  * Should not be used directly but via the JUnit 4 rule or JUnit 5 extension.
  */
 @ConsumerType
+@SuppressWarnings("java:S112") // allow throwing RuntimException
 public class AemContextImpl extends SlingContextImpl {
 
   // default to publish instance run mode

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/package-info.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/package-info.java
@@ -20,5 +20,5 @@
 /**
  * AEM context implementation for unit tests.
  */
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package io.wcm.testing.mock.aem.context;

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
+import com.day.cq.dam.api.Rendition;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -33,7 +34,6 @@ import org.osgi.service.event.EventAdmin;
 
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.AssetManager;
-import com.day.cq.dam.api.Rendition;
 import com.day.cq.dam.commons.util.DamUtil;
 
 /**
@@ -45,7 +45,10 @@ import com.day.cq.dam.commons.util.DamUtil;
         AdapterFactory.ADAPTABLE_CLASSES + "=org.apache.sling.api.resource.ResourceResolver",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.dam.api.Asset",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.dam.api.AssetManager",
-        AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.dam.api.Rendition"
+        AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.dam.api.Rendition",
+        AdapterFactory.ADAPTER_CLASSES + "=com.adobe.granite.asset.api.Asset",
+        AdapterFactory.ADAPTER_CLASSES + "=com.adobe.granite.asset.api.AssetManager",
+        AdapterFactory.ADAPTER_CLASSES + "=com.adobe.granite.asset.api.Rendition"
     })
 @ProviderType
 public final class MockAemDamAdapterFactory implements AdapterFactory {
@@ -73,11 +76,15 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
 
   @SuppressWarnings("unchecked")
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final Resource resource, @NotNull final Class<AdapterType> type) {
-    if (type == Asset.class && DamUtil.isAsset(resource)) {
-      return (AdapterType)new MockAsset(resource, eventAdmin, bundleContext);
+    if (DamUtil.isAsset(resource)) {
+      if (type == com.adobe.granite.asset.api.Asset.class) {
+        return (AdapterType) new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext));
+      } else if (type == Asset.class) {
+        return (AdapterType) new MockAsset(resource, eventAdmin, bundleContext);
+      }
     }
-    if (type == Rendition.class && DamUtil.isRendition(resource)) {
-      return (AdapterType)new MockRendition(resource);
+    if ((type == Rendition.class || type == com.adobe.granite.asset.api.Rendition.class) && DamUtil.isRendition(resource)) {
+      return (AdapterType) new MockRendition(resource);
     }
     return null;
   }
@@ -85,7 +92,9 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
   @SuppressWarnings("unchecked")
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final ResourceResolver resolver, @NotNull final Class<AdapterType> type) {
     if (type == AssetManager.class) {
-      return (AdapterType)new MockAssetManager(resolver, eventAdmin, bundleContext);
+      return (AdapterType) new MockAssetManager(resolver, eventAdmin, bundleContext);
+    } else if(type == com.adobe.granite.asset.api.AssetManager.class) {
+      return (AdapterType) new MockGraniteAssetManagerWrapper(resolver);
     }
     return null;
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
@@ -74,29 +74,27 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
     return null;
   }
 
-  @SuppressWarnings("unchecked")
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final Resource resource, @NotNull final Class<AdapterType> type) {
     if (DamUtil.isAsset(resource)) {
       if (type == com.adobe.granite.asset.api.Asset.class) {
-        return (AdapterType)new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext));
+        return type.cast(new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext)));
       }
       else if (type == Asset.class) {
-        return (AdapterType)new MockAsset(resource, eventAdmin, bundleContext);
+        return type.cast(new MockAsset(resource, eventAdmin, bundleContext));
       }
     }
     if ((type == Rendition.class || type == com.adobe.granite.asset.api.Rendition.class) && DamUtil.isRendition(resource)) {
-      return (AdapterType)new MockRendition(resource);
+      return type.cast(new MockRendition(resource));
     }
     return null;
   }
 
-  @SuppressWarnings("unchecked")
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final ResourceResolver resolver, @NotNull final Class<AdapterType> type) {
     if (type == AssetManager.class) {
-      return (AdapterType)new MockAssetManager(resolver, eventAdmin, bundleContext);
+      return type.cast(new MockAssetManager(resolver, eventAdmin, bundleContext));
     }
     else if (type == com.adobe.granite.asset.api.AssetManager.class) {
-      return (AdapterType)new MockGraniteAssetManagerWrapper(resolver);
+      return type.cast(new MockGraniteAssetManagerWrapper(resolver));
     }
     return null;
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
@@ -19,7 +19,6 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import com.day.cq.dam.api.Rendition;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -34,6 +33,7 @@ import org.osgi.service.event.EventAdmin;
 
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.AssetManager;
+import com.day.cq.dam.api.Rendition;
 import com.day.cq.dam.commons.util.DamUtil;
 
 /**
@@ -78,13 +78,14 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final Resource resource, @NotNull final Class<AdapterType> type) {
     if (DamUtil.isAsset(resource)) {
       if (type == com.adobe.granite.asset.api.Asset.class) {
-        return (AdapterType) new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext));
-      } else if (type == Asset.class) {
-        return (AdapterType) new MockAsset(resource, eventAdmin, bundleContext);
+        return (AdapterType)new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext));
+      }
+      else if (type == Asset.class) {
+        return (AdapterType)new MockAsset(resource, eventAdmin, bundleContext);
       }
     }
     if ((type == Rendition.class || type == com.adobe.granite.asset.api.Rendition.class) && DamUtil.isRendition(resource)) {
-      return (AdapterType) new MockRendition(resource);
+      return (AdapterType)new MockRendition(resource);
     }
     return null;
   }
@@ -92,9 +93,10 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
   @SuppressWarnings("unchecked")
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final ResourceResolver resolver, @NotNull final Class<AdapterType> type) {
     if (type == AssetManager.class) {
-      return (AdapterType) new MockAssetManager(resolver, eventAdmin, bundleContext);
-    } else if(type == com.adobe.granite.asset.api.AssetManager.class) {
-      return (AdapterType) new MockGraniteAssetManagerWrapper(resolver);
+      return (AdapterType)new MockAssetManager(resolver, eventAdmin, bundleContext);
+    }
+    else if (type == com.adobe.granite.asset.api.AssetManager.class) {
+      return (AdapterType)new MockGraniteAssetManagerWrapper(resolver);
     }
     return null;
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
@@ -43,6 +43,7 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.EventAdmin;
 
+import com.adobe.granite.asset.api.RenditionHandler;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
@@ -246,13 +247,17 @@ class MockAsset extends ResourceWrapper implements Asset {
     return resource.getValueMap().get(JcrConstants.JCR_UUID, "");
   }
 
-
-  // --- unsupported operations ---
-
   @Override
   public Rendition addRendition(String name, InputStream is, Map<String, Object> map) {
-    throw new UnsupportedOperationException();
+    Object mimeTypeObject = map.get(RenditionHandler.PROPERTY_RENDITION_MIME_TYPE);
+    if (mimeTypeObject instanceof String) {
+      return addRendition(name, is, mimeTypeObject.toString());
+    }
+    throw new UnsupportedOperationException("Mime type property missing in map: " + RenditionHandler.PROPERTY_RENDITION_MIME_TYPE);
   }
+
+
+  // --- unsupported operations ---
 
   @Override
   public Rendition getCurrentOriginal() {

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
@@ -19,20 +19,37 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import com.day.cq.commons.jcr.JcrConstants;
-import com.day.cq.dam.api.*;
+import java.io.InputStream;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.Binary;
+
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.security.user.User;
-import org.apache.sling.api.resource.*;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.resource.ResourceWrapper;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.EventAdmin;
 
-import javax.jcr.Binary;
-import java.io.InputStream;
-import java.util.*;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.api.DamEvent;
+import com.day.cq.dam.api.Rendition;
+import com.day.cq.dam.api.RenditionPicker;
+import com.day.cq.dam.api.Revision;
 
 /**
  * Mock implementation of {@link Asset}.
@@ -63,11 +80,11 @@ class MockAsset extends ResourceWrapper implements Asset {
   @Override
   public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
     if (type == Resource.class) {
-      return (AdapterType) resource;
+      return (AdapterType)resource;
     }
     //to be able to adapt to granite asset
     if (type == com.adobe.granite.asset.api.Asset.class) {
-      return (AdapterType) new MockGraniteAssetWrapper(this);
+      return (AdapterType)new MockGraniteAssetWrapper(this);
     }
     return super.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
@@ -76,15 +76,14 @@ class MockAsset extends ResourceWrapper implements Asset {
     this.bundleContext = bundleContext;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
     if (type == Resource.class) {
-      return (AdapterType)resource;
+      return type.cast(resource);
     }
     //to be able to adapt to granite asset
     if (type == com.adobe.granite.asset.api.Asset.class) {
-      return (AdapterType)new MockGraniteAssetWrapper(this);
+      return type.cast(new MockGraniteAssetWrapper(this));
     }
     return super.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
@@ -19,37 +19,20 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import java.io.InputStream;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.jcr.Binary;
-
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.dam.api.*;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.security.user.User;
-import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.resource.ResourceWrapper;
-import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.resource.*;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.EventAdmin;
 
-import com.day.cq.commons.jcr.JcrConstants;
-import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.DamConstants;
-import com.day.cq.dam.api.DamEvent;
-import com.day.cq.dam.api.Rendition;
-import com.day.cq.dam.api.RenditionPicker;
-import com.day.cq.dam.api.Revision;
+import javax.jcr.Binary;
+import java.io.InputStream;
+import java.util.*;
 
 /**
  * Mock implementation of {@link Asset}.
@@ -80,7 +63,11 @@ class MockAsset extends ResourceWrapper implements Asset {
   @Override
   public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
     if (type == Resource.class) {
-      return (AdapterType)resource;
+      return (AdapterType) resource;
+    }
+    //to be able to adapt to granite asset
+    if (type == com.adobe.granite.asset.api.Asset.class) {
+      return (AdapterType) new MockGraniteAssetWrapper(this);
     }
     return super.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -1,0 +1,74 @@
+package io.wcm.testing.mock.aem.dam;
+
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetManager;
+import com.day.cq.dam.api.DamConstants;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Mock implementation of Adobe Granite {@link AssetManager}. This is done by wrapping a {@link MockAssetManager}.
+ */
+public class MockGraniteAssetManagerWrapper implements AssetManager {
+
+    private final ResourceResolver resourceResolver;
+    private final com.day.cq.dam.api.AssetManager cqAssetManager;
+
+    MockGraniteAssetManagerWrapper(@NotNull ResourceResolver resourceResolver) {
+        this.resourceResolver = resourceResolver;
+        this.cqAssetManager = resourceResolver.adaptTo(com.day.cq.dam.api.AssetManager.class);
+    }
+
+    @Override
+    public Asset createAsset(String s) {
+        com.day.cq.dam.api.Asset asset = cqAssetManager.createAsset(s, null, null, false);
+        if (asset instanceof MockAsset) {
+            return new MockGraniteAssetWrapper((MockAsset) asset);
+        }
+        throw new UnsupportedOperationException("Not in a mock context");
+    }
+
+    @Override
+    public Asset getAsset(String s) {
+        Resource resource = resourceResolver.getResource(s);
+        return resource != null ? resource.adaptTo(Asset.class) : null;
+    }
+
+    @Override
+    public Asset getAssetByIdentifier(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean assetExists(String s) {
+        Resource assetResource = resourceResolver.getResource(s);
+        return assetResource != null && Objects.equals(DamConstants.NT_DAM_ASSET, assetResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
+    }
+
+    @Override
+    public void removeAsset(String s) {
+        try {
+            Resource assetResource = resourceResolver.getResource(s);
+            if (assetResource != null) {
+                resourceResolver.delete(assetResource);
+            }
+        } catch (PersistenceException pe) {
+            throw new RuntimeException(pe);
+        }
+    }
+
+    @Override
+    public void copyAsset(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void moveAsset(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -60,11 +60,6 @@ public class MockGraniteAssetManagerWrapper implements AssetManager {
   }
 
   @Override
-  public Asset getAssetByIdentifier(String s) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public boolean assetExists(String s) {
     Resource assetResource = resourceResolver.getResource(s);
     return assetResource != null && Objects.equals(DamConstants.NT_DAM_ASSET, assetResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
@@ -81,6 +76,14 @@ public class MockGraniteAssetManagerWrapper implements AssetManager {
     catch (PersistenceException pe) {
       throw new RuntimeException(pe);
     }
+  }
+
+
+  // --- unsupported operations ---
+
+  @Override
+  public Asset getAssetByIdentifier(String s) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -63,6 +63,7 @@ public class MockGraniteAssetManagerWrapper implements AssetManager {
   }
 
   @Override
+  @SuppressWarnings("java:S112") // allow throwing RuntimException
   public void removeAsset(String s) {
     try {
       Resource assetResource = resourceResolver.getResource(s);

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -47,10 +47,7 @@ public class MockGraniteAssetManagerWrapper implements AssetManager {
   @Override
   public Asset createAsset(String s) {
     com.day.cq.dam.api.Asset asset = cqAssetManager.createAsset(s, null, null, false);
-    if (asset instanceof MockAsset) {
-      return new MockGraniteAssetWrapper((MockAsset)asset);
-    }
-    throw new UnsupportedOperationException("Not in a mock context");
+    return new MockGraniteAssetWrapper(asset);
   }
 
   @Override

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -1,74 +1,95 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package io.wcm.testing.mock.aem.dam;
 
-import com.adobe.granite.asset.api.Asset;
-import com.adobe.granite.asset.api.AssetManager;
-import com.day.cq.dam.api.DamConstants;
+import java.util.Objects;
+
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetManager;
+import com.day.cq.dam.api.DamConstants;
 
 /**
  * Mock implementation of Adobe Granite {@link AssetManager}. This is done by wrapping a {@link MockAssetManager}.
  */
 public class MockGraniteAssetManagerWrapper implements AssetManager {
 
-    private final ResourceResolver resourceResolver;
-    private final com.day.cq.dam.api.AssetManager cqAssetManager;
+  private final ResourceResolver resourceResolver;
+  private final com.day.cq.dam.api.AssetManager cqAssetManager;
 
-    MockGraniteAssetManagerWrapper(@NotNull ResourceResolver resourceResolver) {
-        this.resourceResolver = resourceResolver;
-        this.cqAssetManager = resourceResolver.adaptTo(com.day.cq.dam.api.AssetManager.class);
-    }
+  MockGraniteAssetManagerWrapper(@NotNull ResourceResolver resourceResolver) {
+    this.resourceResolver = resourceResolver;
+    this.cqAssetManager = resourceResolver.adaptTo(com.day.cq.dam.api.AssetManager.class);
+  }
 
-    @Override
-    public Asset createAsset(String s) {
-        com.day.cq.dam.api.Asset asset = cqAssetManager.createAsset(s, null, null, false);
-        if (asset instanceof MockAsset) {
-            return new MockGraniteAssetWrapper((MockAsset) asset);
-        }
-        throw new UnsupportedOperationException("Not in a mock context");
+  @Override
+  public Asset createAsset(String s) {
+    com.day.cq.dam.api.Asset asset = cqAssetManager.createAsset(s, null, null, false);
+    if (asset instanceof MockAsset) {
+      return new MockGraniteAssetWrapper((MockAsset)asset);
     }
+    throw new UnsupportedOperationException("Not in a mock context");
+  }
 
-    @Override
-    public Asset getAsset(String s) {
-        Resource resource = resourceResolver.getResource(s);
-        return resource != null ? resource.adaptTo(Asset.class) : null;
-    }
+  @Override
+  public Asset getAsset(String s) {
+    Resource resource = resourceResolver.getResource(s);
+    return resource != null ? resource.adaptTo(Asset.class) : null;
+  }
 
-    @Override
-    public Asset getAssetByIdentifier(String s) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Asset getAssetByIdentifier(String s) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public boolean assetExists(String s) {
-        Resource assetResource = resourceResolver.getResource(s);
-        return assetResource != null && Objects.equals(DamConstants.NT_DAM_ASSET, assetResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
-    }
+  @Override
+  public boolean assetExists(String s) {
+    Resource assetResource = resourceResolver.getResource(s);
+    return assetResource != null && Objects.equals(DamConstants.NT_DAM_ASSET, assetResource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class));
+  }
 
-    @Override
-    public void removeAsset(String s) {
-        try {
-            Resource assetResource = resourceResolver.getResource(s);
-            if (assetResource != null) {
-                resourceResolver.delete(assetResource);
-            }
-        } catch (PersistenceException pe) {
-            throw new RuntimeException(pe);
-        }
+  @Override
+  public void removeAsset(String s) {
+    try {
+      Resource assetResource = resourceResolver.getResource(s);
+      if (assetResource != null) {
+        resourceResolver.delete(assetResource);
+      }
     }
+    catch (PersistenceException pe) {
+      throw new RuntimeException(pe);
+    }
+  }
 
-    @Override
-    public void copyAsset(String s, String s1) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void copyAsset(String s, String s1) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void moveAsset(String s, String s1) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void moveAsset(String s, String s1) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -1,139 +1,160 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package io.wcm.testing.mock.aem.dam;
 
-import com.adobe.granite.asset.api.Asset;
-import com.adobe.granite.asset.api.AssetMetadata;
-import com.adobe.granite.asset.api.AssetRelation;
-import com.adobe.granite.asset.api.Rendition;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.ResourceWrapper;
-
-import javax.jcr.Binary;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import javax.jcr.Binary;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.ResourceWrapper;
+
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetMetadata;
+import com.adobe.granite.asset.api.AssetRelation;
+import com.adobe.granite.asset.api.Rendition;
+
 /**
- * Mock implementation of Adobe Granite {@link Asset}.  This is done by wrapping a {@link MockAsset}
+ * Mock implementation of Adobe Granite {@link Asset}. This is done by wrapping a {@link MockAsset}
  */
 @SuppressWarnings("null")
 public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
 
-    private final MockAsset asset;
+  private final MockAsset asset;
 
-    MockGraniteAssetWrapper(MockAsset asset) {
-        super(asset.getResource());
-        this.asset = asset;
-    }
+  MockGraniteAssetWrapper(MockAsset asset) {
+    super(asset.getResource());
+    this.asset = asset;
+  }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
-        //to be able to adapt to CQ asset
-        if (type == com.day.cq.dam.api.Asset.class) {
-            return (AdapterType) asset;
-        }
-        return asset.adaptTo(type);
+  @SuppressWarnings("unchecked")
+  @Override
+  public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+    //to be able to adapt to CQ asset
+    if (type == com.day.cq.dam.api.Asset.class) {
+      return (AdapterType)asset;
     }
+    return asset.adaptTo(type);
+  }
 
-    @Override
-    public com.adobe.granite.asset.api.Rendition getRendition(String s) {
-        return (com.adobe.granite.asset.api.Rendition) asset.getRendition(s);
-    }
+  @Override
+  public com.adobe.granite.asset.api.Rendition getRendition(String s) {
+    return (com.adobe.granite.asset.api.Rendition)asset.getRendition(s);
+  }
 
-    @Override
-    public Iterator<? extends Rendition> listRenditions() {
-        List<Rendition> graniteRenditions = new LinkedList<>();
-        Iterator<? extends com.day.cq.dam.api.Rendition> renditions = asset.listRenditions();
-        while (renditions.hasNext()) {
-            graniteRenditions.add((com.adobe.granite.asset.api.Rendition) renditions.next());
-        }
-        return graniteRenditions.iterator();
+  @Override
+  public Iterator<? extends Rendition> listRenditions() {
+    List<Rendition> graniteRenditions = new LinkedList<>();
+    Iterator<? extends com.day.cq.dam.api.Rendition> renditions = asset.listRenditions();
+    while (renditions.hasNext()) {
+      graniteRenditions.add((com.adobe.granite.asset.api.Rendition)renditions.next());
     }
+    return graniteRenditions.iterator();
+  }
 
-    @Override
-    public String getIdentifier() {
-        return asset.getID();
-    }
+  @Override
+  public String getIdentifier() {
+    return asset.getID();
+  }
 
-    @Override
-    public com.adobe.granite.asset.api.Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
-        if (map.size() == 1) {
-            Object val = map.values().iterator().next();
-            if (val != null) {
-                return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, inputStream, val.toString());
-            }
-        }
-        return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, inputStream, map);
+  @Override
+  public com.adobe.granite.asset.api.Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
+    if (map.size() == 1) {
+      Object val = map.values().iterator().next();
+      if (val != null) {
+        return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, inputStream, val.toString());
+      }
     }
+    return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, inputStream, map);
+  }
 
-    @Override
-    public com.adobe.granite.asset.api.Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
-        return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, binary, map);
-    }
+  @Override
+  public com.adobe.granite.asset.api.Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
+    return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, binary, map);
+  }
 
-    @Override
-    public void removeRendition(String s) {
-        asset.removeRendition(s);
-    }
+  @Override
+  public void removeRendition(String s) {
+    asset.removeRendition(s);
+  }
 
-    @Override
-    public Iterator<? extends com.adobe.granite.asset.api.Asset> listRelated(String s) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Iterator<? extends com.adobe.granite.asset.api.Asset> listRelated(String s) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Iterator<? extends AssetRelation> listRelations(String s) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public Iterator<? extends AssetRelation> listRelations(String s) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public AssetMetadata getAssetMetadata() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public AssetMetadata getAssetMetadata() {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public AssetRelation addRelation(String s, String s1, Map<String, Object> map) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public AssetRelation addRelation(String s, String s1, Map<String, Object> map) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void setRelation(String s, String s1) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void setRelation(String s, String s1) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public AssetRelation addRelation(String s, String s1) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public AssetRelation addRelation(String s, String s1) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void orderRelationBefore(String s, String s1, String s2) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void orderRelationBefore(String s, String s1, String s2) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void removeRelation(String s, String s1) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void removeRelation(String s, String s1) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public void removeRelation(String s) {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public void removeRelation(String s) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public int hashCode() {
-        return getPath().hashCode();
-    }
+  @Override
+  public int hashCode() {
+    return getPath().hashCode();
+  }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof MockGraniteAssetWrapper)) {
-            return false;
-        }
-        return StringUtils.equals(getPath(), ((MockGraniteAssetWrapper)obj).getPath());
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof MockGraniteAssetWrapper)) {
+      return false;
     }
+    return StringUtils.equals(getPath(), ((MockGraniteAssetWrapper)obj).getPath());
+  }
 
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -1,0 +1,139 @@
+package io.wcm.testing.mock.aem.dam;
+
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetMetadata;
+import com.adobe.granite.asset.api.AssetRelation;
+import com.adobe.granite.asset.api.Rendition;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.ResourceWrapper;
+
+import javax.jcr.Binary;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock implementation of Adobe Granite {@link Asset}.  This is done by wrapping a {@link MockAsset}
+ */
+@SuppressWarnings("null")
+public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
+
+    private final MockAsset asset;
+
+    MockGraniteAssetWrapper(MockAsset asset) {
+        super(asset.getResource());
+        this.asset = asset;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+        //to be able to adapt to CQ asset
+        if (type == com.day.cq.dam.api.Asset.class) {
+            return (AdapterType) asset;
+        }
+        return asset.adaptTo(type);
+    }
+
+    @Override
+    public com.adobe.granite.asset.api.Rendition getRendition(String s) {
+        return (com.adobe.granite.asset.api.Rendition) asset.getRendition(s);
+    }
+
+    @Override
+    public Iterator<? extends Rendition> listRenditions() {
+        List<Rendition> graniteRenditions = new LinkedList<>();
+        Iterator<? extends com.day.cq.dam.api.Rendition> renditions = asset.listRenditions();
+        while (renditions.hasNext()) {
+            graniteRenditions.add((com.adobe.granite.asset.api.Rendition) renditions.next());
+        }
+        return graniteRenditions.iterator();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return asset.getID();
+    }
+
+    @Override
+    public com.adobe.granite.asset.api.Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
+        if (map.size() == 1) {
+            Object val = map.values().iterator().next();
+            if (val != null) {
+                return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, inputStream, val.toString());
+            }
+        }
+        return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, inputStream, map);
+    }
+
+    @Override
+    public com.adobe.granite.asset.api.Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
+        return (com.adobe.granite.asset.api.Rendition) asset.addRendition(s, binary, map);
+    }
+
+    @Override
+    public void removeRendition(String s) {
+        asset.removeRendition(s);
+    }
+
+    @Override
+    public Iterator<? extends com.adobe.granite.asset.api.Asset> listRelated(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<? extends AssetRelation> listRelations(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AssetMetadata getAssetMetadata() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AssetRelation addRelation(String s, String s1, Map<String, Object> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRelation(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AssetRelation addRelation(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void orderRelationBefore(String s, String s1, String s2) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeRelation(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeRelation(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int hashCode() {
+        return getPath().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof MockGraniteAssetWrapper)) {
+            return false;
+        }
+        return StringUtils.equals(getPath(), ((MockGraniteAssetWrapper)obj).getPath());
+    }
+
+}

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -82,19 +82,8 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
   }
 
   @Override
-  public Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
-    if (map.size() == 1) {
-      Object val = map.values().iterator().next();
-      if (val != null) {
-        return (Rendition)asset.addRendition(s, inputStream, val.toString());
-      }
-    }
-    return (Rendition)asset.addRendition(s, inputStream, map);
-  }
-
-  @Override
-  public Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
-    return (Rendition)asset.addRendition(s, binary, map);
+  public Rendition setRendition(String name, InputStream inputStream, Map<String, Object> map) {
+    return (Rendition)asset.addRendition(name, inputStream, map);
   }
 
   @Override
@@ -130,6 +119,11 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
 
   @Override
   public AssetMetadata getAssetMetadata() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.jcr.Binary;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
 
 import com.adobe.granite.asset.api.Asset;
@@ -41,10 +42,10 @@ import com.adobe.granite.asset.api.Rendition;
 @SuppressWarnings("null")
 public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
 
-  private final MockAsset asset;
+  private final com.day.cq.dam.api.Asset asset;
 
-  MockGraniteAssetWrapper(MockAsset asset) {
-    super(asset.getResource());
+  MockGraniteAssetWrapper(com.day.cq.dam.api.Asset asset) {
+    super(asset.adaptTo(Resource.class));
     this.asset = asset;
   }
 

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -49,12 +49,11 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
     this.asset = asset;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
     //to be able to adapt to CQ asset
     if (type == com.day.cq.dam.api.Asset.class) {
-      return (AdapterType)asset;
+      return type.cast(asset);
     }
     return asset.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -36,6 +36,8 @@ import com.adobe.granite.asset.api.AssetMetadata;
 import com.adobe.granite.asset.api.AssetRelation;
 import com.adobe.granite.asset.api.Rendition;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Mock implementation of Adobe Granite {@link Asset}. This is done by wrapping a {@link MockAsset}
  */
@@ -44,6 +46,7 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
 
   private final com.day.cq.dam.api.Asset asset;
 
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // adaption to Resource will always work
   MockGraniteAssetWrapper(com.day.cq.dam.api.Asset asset) {
     super(asset.adaptTo(Resource.class));
     this.asset = asset;

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -59,16 +59,16 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
   }
 
   @Override
-  public com.adobe.granite.asset.api.Rendition getRendition(String s) {
-    return (com.adobe.granite.asset.api.Rendition)asset.getRendition(s);
+  public Rendition getRendition(String s) {
+    return (Rendition)asset.getRendition(s);
   }
 
   @Override
   public Iterator<? extends Rendition> listRenditions() {
     List<Rendition> graniteRenditions = new LinkedList<>();
-    Iterator<? extends com.day.cq.dam.api.Rendition> renditions = asset.listRenditions();
+    Iterator<com.day.cq.dam.api.Rendition> renditions = asset.listRenditions();
     while (renditions.hasNext()) {
-      graniteRenditions.add((com.adobe.granite.asset.api.Rendition)renditions.next());
+      graniteRenditions.add((Rendition)renditions.next());
     }
     return graniteRenditions.iterator();
   }
@@ -79,19 +79,19 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
   }
 
   @Override
-  public com.adobe.granite.asset.api.Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
+  public Rendition setRendition(String s, InputStream inputStream, Map<String, Object> map) {
     if (map.size() == 1) {
       Object val = map.values().iterator().next();
       if (val != null) {
-        return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, inputStream, val.toString());
+        return (Rendition)asset.addRendition(s, inputStream, val.toString());
       }
     }
-    return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, inputStream, map);
+    return (Rendition)asset.addRendition(s, inputStream, map);
   }
 
   @Override
-  public com.adobe.granite.asset.api.Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
-    return (com.adobe.granite.asset.api.Rendition)asset.addRendition(s, binary, map);
+  public Rendition setRendition(String s, Binary binary, Map<String, Object> map) {
+    return (Rendition)asset.addRendition(s, binary, map);
   }
 
   @Override
@@ -100,7 +100,23 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
   }
 
   @Override
-  public Iterator<? extends com.adobe.granite.asset.api.Asset> listRelated(String s) {
+  public int hashCode() {
+    return getPath().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof MockGraniteAssetWrapper)) {
+      return false;
+    }
+    return StringUtils.equals(getPath(), ((MockGraniteAssetWrapper)obj).getPath());
+  }
+
+
+  // --- unsupported operations ---
+
+  @Override
+  public Iterator<? extends Asset> listRelated(String s) {
     throw new UnsupportedOperationException();
   }
 
@@ -142,19 +158,6 @@ public class MockGraniteAssetWrapper extends ResourceWrapper implements Asset {
   @Override
   public void removeRelation(String s) {
     throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public int hashCode() {
-    return getPath().hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof MockGraniteAssetWrapper)) {
-      return false;
-    }
-    return StringUtils.equals(getPath(), ((MockGraniteAssetWrapper)obj).getPath());
   }
 
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockRendition.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockRendition.java
@@ -62,7 +62,7 @@ class MockRendition extends ResourceWrapper implements Rendition, com.adobe.gran
     }
     //to be able to adapt to granite rendition and back
     if (type == Rendition.class || type == com.adobe.granite.asset.api.Rendition.class) {
-      return (AdapterType) this;
+      return (AdapterType)this;
     }
     return super.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockRendition.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockRendition.java
@@ -38,10 +38,10 @@ import com.day.cq.dam.api.Rendition;
 import com.day.cq.dam.commons.util.DamUtil;
 
 /**
- * Mock implementation of {@link Rendition}.
+ * Mock implementation of {@link Rendition} and {@link com.adobe.granite.asset.api.Rendition}.
  */
 @SuppressWarnings("null")
-class MockRendition extends ResourceWrapper implements Rendition {
+class MockRendition extends ResourceWrapper implements Rendition, com.adobe.granite.asset.api.Rendition {
 
   private final Resource resource;
   private final Resource contentResource;
@@ -59,6 +59,10 @@ class MockRendition extends ResourceWrapper implements Rendition {
   public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
     if (type == Resource.class) {
       return (AdapterType)resource;
+    }
+    //to be able to adapt to granite rendition and back
+    if (type == Rendition.class || type == com.adobe.granite.asset.api.Rendition.class) {
+      return (AdapterType) this;
     }
     return super.adaptTo(type);
   }

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/package-info.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Mock implementation of selected AEM DAM APIs.
  */
-@org.osgi.annotation.versioning.Version("2.3.0")
+@org.osgi.annotation.versioning.Version("2.4.0")
 package io.wcm.testing.mock.aem.dam;

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -69,7 +69,6 @@ public class MockAssetTest {
 
     Resource resource = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg");
     this.asset = resource.adaptTo(Asset.class);
-    Object o = resource.adaptTo(com.adobe.granite.asset.api.Asset.class);
 
     damEventHandler = (DamEventHandler)context.registerService(EventHandler.class, new DamEventHandler());
   }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -19,9 +19,19 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.service.event.EventHandler;
 
+import com.adobe.granite.asset.api.RenditionHandler;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
 import com.day.cq.dam.api.DamEvent;
@@ -42,8 +53,6 @@ import com.day.cq.wcm.foundation.WCMRenditionPicker;
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.dam.MockAssetManagerTest.DamEventHandler;
 import io.wcm.testing.mock.aem.junit.AemContext;
-
-import static org.junit.Assert.*;
 
 @SuppressWarnings("null")
 public class MockAssetTest {
@@ -143,6 +152,22 @@ public class MockAssetTest {
   @Test
   public void testAddRemoveRendition() {
     doTestAddRemoveRendition("test.bin");
+  }
+
+  @Test
+  public void testAddRenditionWithMap() {
+    InputStream is = new ByteArrayInputStream(BINARY_DATA);
+    Rendition rendition = asset.addRendition("rendition1", is, Map.of(RenditionHandler.PROPERTY_RENDITION_MIME_TYPE, "application/octet-stream"));
+    assertNotNull(rendition);
+  }
+
+  @Test
+  public void testAddRenditionWithMapWithoutMimetype() {
+    InputStream is = new ByteArrayInputStream(BINARY_DATA);
+    Map<String, Object> emptyMap = Map.of();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      asset.addRendition("rendition1", is, emptyMap);
+    });
   }
 
   @Test

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -223,6 +224,12 @@ public class MockAssetTest {
     assertNotNull(graniteAsset);
     assertEquals(asset, graniteAsset.adaptTo(Asset.class));
     assertEquals(graniteAsset.adaptTo(Resource.class), asset.adaptTo(Resource.class));
+  }
+
+  @Test
+  public void testAdaptTo() {
+    assertSame(asset, asset.adaptTo(Asset.class));
+    assertSame(asset, asset.adaptTo(com.adobe.granite.asset.api.Asset.class).adaptTo(Asset.class));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -197,6 +197,7 @@ public class MockAssetTest {
     com.adobe.granite.asset.api.Asset graniteAsset = asset.adaptTo(com.adobe.granite.asset.api.Asset.class);
     assertNotNull(graniteAsset);
     assertEquals(asset, graniteAsset.adaptTo(Asset.class));
+    assertEquals(graniteAsset.adaptTo(Resource.class), asset.adaptTo(Resource.class));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -19,13 +19,6 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
@@ -49,6 +42,8 @@ import com.day.cq.wcm.foundation.WCMRenditionPicker;
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.dam.MockAssetManagerTest.DamEventHandler;
 import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.junit.Assert.*;
 
 @SuppressWarnings("null")
 public class MockAssetTest {
@@ -190,7 +185,11 @@ public class MockAssetTest {
 
   @Test
   public void testRemoveNonExistingRendition() {
-    asset.removeRendition("non-existing");
+    try {
+      asset.removeRendition("non-existing");
+    } catch (Exception e) {
+      fail("removeRendition should not fail on non-existing renditions!");
+    }
   }
 
   @Test

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -69,6 +69,7 @@ public class MockAssetTest {
 
     Resource resource = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg");
     this.asset = resource.adaptTo(Asset.class);
+    Object o = resource.adaptTo(com.adobe.granite.asset.api.Asset.class);
 
     damEventHandler = (DamEventHandler)context.registerService(EventHandler.class, new DamEventHandler());
   }
@@ -191,6 +192,13 @@ public class MockAssetTest {
   @Test
   public void testRemoveNonExistingRendition() {
     asset.removeRendition("non-existing");
+  }
+
+  @Test
+  public void testGraniteAdaptation() {
+    com.adobe.granite.asset.api.Asset graniteAsset = asset.adaptTo(com.adobe.granite.asset.api.Asset.class);
+    assertNotNull(graniteAsset);
+    assertEquals(asset, graniteAsset.adaptTo(Asset.class));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapperTest.java
@@ -1,0 +1,54 @@
+package io.wcm.testing.mock.aem.dam;
+
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetManager;
+import com.day.cq.commons.jcr.JcrConstants;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MockGraniteAssetManagerWrapperTest {
+
+    private static final String TEST_ASSET_PATH = "/content/dam/test-asset";
+
+    @Rule
+    public final AemContext context = TestAemContext.newAemContext();
+
+    private ResourceResolver resourceResolver;
+    private AssetManager assetManager;
+
+    @Before
+    public void setUp() {
+        resourceResolver = context.resourceResolver();
+        assetManager = context.graniteAssetManager();
+    }
+
+    @Test
+    public void testBasicAssetFunctionality() {
+        assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
+        assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
+
+        Asset asset = assetManager.createAsset(TEST_ASSET_PATH);
+        assertNotNull(asset);
+        assertEquals("dam:Asset", asset.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE));
+        assertTrue(assetManager.assetExists(TEST_ASSET_PATH));
+        Resource assetResource = resourceResolver.getResource(TEST_ASSET_PATH);
+        assertNotNull(assetResource);
+        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT));
+        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/metadata"));
+        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/renditions"));
+
+        assertEquals(asset, assetManager.getAsset(TEST_ASSET_PATH));
+
+        assetManager.removeAsset(TEST_ASSET_PATH);
+        assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
+        assertNull(assetManager.getAsset(TEST_ASSET_PATH));
+        assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
+    }
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapperTest.java
@@ -1,54 +1,80 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package io.wcm.testing.mock.aem.dam;
 
-import com.adobe.granite.asset.api.Asset;
-import com.adobe.granite.asset.api.AssetManager;
-import com.day.cq.commons.jcr.JcrConstants;
-import io.wcm.testing.mock.aem.context.TestAemContext;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.AssetManager;
+import com.day.cq.commons.jcr.JcrConstants;
+
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 public class MockGraniteAssetManagerWrapperTest {
 
-    private static final String TEST_ASSET_PATH = "/content/dam/test-asset";
+  private static final String TEST_ASSET_PATH = "/content/dam/test-asset";
 
-    @Rule
-    public final AemContext context = TestAemContext.newAemContext();
+  @Rule
+  public final AemContext context = TestAemContext.newAemContext();
 
-    private ResourceResolver resourceResolver;
-    private AssetManager assetManager;
+  private ResourceResolver resourceResolver;
+  private AssetManager assetManager;
 
-    @Before
-    public void setUp() {
-        resourceResolver = context.resourceResolver();
-        assetManager = context.graniteAssetManager();
-    }
+  @Before
+  public void setUp() {
+    resourceResolver = context.resourceResolver();
+    assetManager = context.graniteAssetManager();
+  }
 
-    @Test
-    public void testBasicAssetFunctionality() {
-        assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
-        assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
+  @Test
+  public void testBasicAssetFunctionality() {
+    assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
+    assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
 
-        Asset asset = assetManager.createAsset(TEST_ASSET_PATH);
-        assertNotNull(asset);
-        assertEquals("dam:Asset", asset.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE));
-        assertTrue(assetManager.assetExists(TEST_ASSET_PATH));
-        Resource assetResource = resourceResolver.getResource(TEST_ASSET_PATH);
-        assertNotNull(assetResource);
-        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT));
-        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/metadata"));
-        assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/renditions"));
+    Asset asset = assetManager.createAsset(TEST_ASSET_PATH);
+    assertNotNull(asset);
+    assertEquals("dam:Asset", asset.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE));
+    assertTrue(assetManager.assetExists(TEST_ASSET_PATH));
+    Resource assetResource = resourceResolver.getResource(TEST_ASSET_PATH);
+    assertNotNull(assetResource);
+    assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT));
+    assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/metadata"));
+    assertNotNull(assetResource.getChild(JcrConstants.JCR_CONTENT + "/renditions"));
 
-        assertEquals(asset, assetManager.getAsset(TEST_ASSET_PATH));
+    assertEquals(asset, assetManager.getAsset(TEST_ASSET_PATH));
 
-        assetManager.removeAsset(TEST_ASSET_PATH);
-        assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
-        assertNull(assetManager.getAsset(TEST_ASSET_PATH));
-        assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
-    }
+    assetManager.removeAsset(TEST_ASSET_PATH);
+    assertNull(resourceResolver.getResource(TEST_ASSET_PATH));
+    assertNull(assetManager.getAsset(TEST_ASSET_PATH));
+    assertFalse(assetManager.assetExists(TEST_ASSET_PATH));
+  }
+
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -60,6 +60,7 @@ public class MockGraniteAssetWrapperTest {
   private MockAssetManagerTest.DamEventHandler damEventHandler;
 
   @Before
+  @SuppressWarnings("null")
   public void setUp() {
     context.load().json("/json-import-samples/dam.json", "/content/dam/sample");
 
@@ -101,11 +102,13 @@ public class MockGraniteAssetWrapperTest {
   }
 
   @Test
+  @SuppressWarnings("java:S2699") // assert not exception is thrown
   public void testRemoveNonExistingRendition() {
     asset.removeRendition("non-existing");
   }
 
   @Test
+  @SuppressWarnings("null")
   public void testEquals() {
     Asset asset1 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
     Asset asset2 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -19,6 +19,13 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
@@ -36,12 +43,11 @@ import org.osgi.service.event.EventHandler;
 
 import com.adobe.granite.asset.api.Asset;
 import com.adobe.granite.asset.api.Rendition;
+import com.adobe.granite.asset.api.RenditionHandler;
 import com.day.cq.dam.api.DamEvent;
 
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.junit.AemContext;
-
-import static org.junit.Assert.*;
 
 public class MockGraniteAssetWrapperTest {
 
@@ -119,7 +125,7 @@ public class MockGraniteAssetWrapperTest {
 
   private void doTestAddRemoveRendition(final String renditionName) {
     InputStream is = new ByteArrayInputStream(BINARY_DATA);
-    Rendition rendition = asset.setRendition(renditionName, is, Map.of("jcr:mimeType", "application/octet-stream"));
+    Rendition rendition = asset.setRendition(renditionName, is, Map.of(RenditionHandler.PROPERTY_RENDITION_MIME_TYPE, "application/octet-stream"));
 
     assertNotNull(rendition);
     assertNotNull(asset.getRendition(renditionName));

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -155,6 +155,7 @@ public class MockGraniteAssetWrapperTest {
     com.day.cq.dam.api.Asset cqAsset = asset.adaptTo(com.day.cq.dam.api.Asset.class);
     assertNotNull(cqAsset);
     assertEquals(asset, cqAsset.adaptTo(Asset.class));
+    assertEquals(cqAsset.adaptTo(Resource.class), asset.adaptTo(Resource.class));
   }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -1,10 +1,36 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package io.wcm.testing.mock.aem.dam;
 
-import com.adobe.granite.asset.api.Asset;
-import com.adobe.granite.asset.api.Rendition;
-import com.day.cq.dam.api.DamEvent;
-import io.wcm.testing.mock.aem.context.TestAemContext;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
@@ -14,118 +40,117 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.service.event.EventHandler;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.Rendition;
+import com.day.cq.dam.api.DamEvent;
 
-import static org.junit.Assert.*;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 public class MockGraniteAssetWrapperTest {
 
-    private static final byte[] BINARY_DATA = new byte[] {
-            0x01, 0x02, 0x03, 0x04, 0x05
-    };
+  private static final byte[] BINARY_DATA = new byte[] {
+      0x01, 0x02, 0x03, 0x04, 0x05
+  };
 
-    @Rule
-    public final AemContext context = TestAemContext.newAemContext();
+  @Rule
+  public final AemContext context = TestAemContext.newAemContext();
 
-    private Asset asset;
-    private MockAssetManagerTest.DamEventHandler damEventHandler;
+  private Asset asset;
+  private MockAssetManagerTest.DamEventHandler damEventHandler;
 
-    @Before
-    public void setUp() {
-        context.load().json("/json-import-samples/dam.json", "/content/dam/sample");
+  @Before
+  public void setUp() {
+    context.load().json("/json-import-samples/dam.json", "/content/dam/sample");
 
-        Resource resource = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg");
-        this.asset = resource.adaptTo(Asset.class);
+    Resource resource = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg");
+    this.asset = resource.adaptTo(Asset.class);
 
-        this.damEventHandler = (MockAssetManagerTest.DamEventHandler) context.registerService(EventHandler.class, new MockAssetManagerTest.DamEventHandler());
+    this.damEventHandler = (MockAssetManagerTest.DamEventHandler)context.registerService(EventHandler.class, new MockAssetManagerTest.DamEventHandler());
+  }
+
+  @Test
+  public void testProperties() {
+    assertEquals("scott_reynolds.jpg", asset.getName());
+    assertEquals("/content/dam/sample/portraits/scott_reynolds.jpg", asset.getPath());
+    assertNotEquals(0, asset.hashCode());
+
+    if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
+      assertNotNull(asset.getIdentifier());
     }
-
-    @Test
-    public void testProperties() {
-        assertEquals("scott_reynolds.jpg", asset.getName());
-        assertEquals("/content/dam/sample/portraits/scott_reynolds.jpg", asset.getPath());
-        assertNotEquals(0, asset.hashCode());
-
-        if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
-            assertNotNull(asset.getIdentifier());
-        }
-        else {
-            assertEquals("442d55b6-d534-4faf-9394-c9c20d095985", asset.getIdentifier());
-        }
+    else {
+      assertEquals("442d55b6-d534-4faf-9394-c9c20d095985", asset.getIdentifier());
     }
+  }
 
-    @Test
-    public void testRenditions() {
-        List<Rendition> renditions = IteratorUtils.toList(asset.listRenditions());
-        assertEquals(4, renditions.size());
-        assertTrue(hasRendition(renditions, "cq5dam.thumbnail.48.48.png"));
-        assertEquals("original", asset.getRendition("original").getName());
+  @Test
+  public void testRenditions() {
+    List<Rendition> renditions = IteratorUtils.toList(asset.listRenditions());
+    assertEquals(4, renditions.size());
+    assertTrue(hasRendition(renditions, "cq5dam.thumbnail.48.48.png"));
+    assertEquals("original", asset.getRendition("original").getName());
+  }
+
+  private boolean hasRendition(List<Rendition> renditions, String renditionName) {
+    for (Rendition rendition : renditions) {
+      if (StringUtils.equals(rendition.getName(), renditionName)) {
+        return true;
+      }
     }
+    return false;
+  }
 
-    private boolean hasRendition(List<Rendition> renditions, String renditionName) {
-        for (Rendition rendition : renditions) {
-            if (StringUtils.equals(rendition.getName(), renditionName)) {
-                return true;
-            }
-        }
-        return false;
-    }
+  @Test
+  public void testRemoveNonExistingRendition() {
+    asset.removeRendition("non-existing");
+  }
 
-    @Test
-    public void testRemoveNonExistingRendition() {
-        asset.removeRendition("non-existing");
-    }
+  @Test
+  public void testEquals() {
+    Asset asset1 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
+    Asset asset2 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
 
-    @Test
-    public void testEquals() {
-        Asset asset1 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
-        Asset asset2 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
+    assertEquals(asset1, asset2);
+  }
 
-        assertEquals(asset1, asset2);
-    }
+  private void doTestAddRemoveRendition(final String renditionName) {
+    InputStream is = new ByteArrayInputStream(BINARY_DATA);
+    Rendition rendition = asset.setRendition(renditionName, is, Map.of("jcr:mimeType", "application/octet-stream"));
 
-    private void doTestAddRemoveRendition(final String renditionName) {
-        InputStream is = new ByteArrayInputStream(BINARY_DATA);
-        Rendition rendition = asset.setRendition(renditionName, is, Map.of("jcr:mimeType", "application/octet-stream"));
+    assertNotNull(rendition);
+    assertNotNull(asset.getRendition(renditionName));
+    Resource resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
+    assertNotNull(resource);
 
-        assertNotNull(rendition);
-        assertNotNull(asset.getRendition(renditionName));
-        Resource resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
-        assertNotNull(resource);
+    Optional<DamEvent> damEvent = damEventHandler.getLastEvent();
+    assertTrue(damEvent.isPresent());
+    assertEquals(DamEvent.Type.RENDITION_UPDATED, damEvent.get().getType());
+    assertEquals(asset.getPath(), damEvent.get().getAssetPath());
+    assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
 
-        Optional<DamEvent> damEvent = damEventHandler.getLastEvent();
-        assertTrue(damEvent.isPresent());
-        assertEquals(DamEvent.Type.RENDITION_UPDATED, damEvent.get().getType());
-        assertEquals(asset.getPath(), damEvent.get().getAssetPath());
-        assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
+    asset.removeRendition(renditionName);
 
-        asset.removeRendition(renditionName);
+    assertNull(asset.getRendition(renditionName));
+    resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
+    assertNull(resource);
 
-        assertNull(asset.getRendition(renditionName));
-        resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
-        assertNull(resource);
+    damEvent = damEventHandler.getLastEvent();
+    assertTrue(damEvent.isPresent());
+    assertEquals(DamEvent.Type.RENDITION_REMOVED, damEvent.get().getType());
+    assertEquals(asset.getPath(), damEvent.get().getAssetPath());
+    assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
+  }
 
-        damEvent = damEventHandler.getLastEvent();
-        assertTrue(damEvent.isPresent());
-        assertEquals(DamEvent.Type.RENDITION_REMOVED, damEvent.get().getType());
-        assertEquals(asset.getPath(), damEvent.get().getAssetPath());
-        assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
-    }
+  @Test
+  public void testAddRemoveRendition() {
+    doTestAddRemoveRendition("test.bin");
+  }
 
-    @Test
-    public void testAddRemoveRendition() {
-        doTestAddRemoveRendition("test.bin");
-    }
-
-    @Test
-    public void testCQAdaptation() {
-        com.day.cq.dam.api.Asset cqAsset = asset.adaptTo(com.day.cq.dam.api.Asset.class);
-        assertNotNull(cqAsset);
-        assertEquals(asset, cqAsset.adaptTo(Asset.class));
-    }
+  @Test
+  public void testCQAdaptation() {
+    com.day.cq.dam.api.Asset cqAsset = asset.adaptTo(com.day.cq.dam.api.Asset.class);
+    assertNotNull(cqAsset);
+    assertEquals(asset, cqAsset.adaptTo(Asset.class));
+  }
 
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -19,12 +19,6 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
@@ -46,6 +40,8 @@ import com.day.cq.dam.api.DamEvent;
 
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.junit.Assert.*;
 
 public class MockGraniteAssetWrapperTest {
 
@@ -102,9 +98,12 @@ public class MockGraniteAssetWrapperTest {
   }
 
   @Test
-  @SuppressWarnings("java:S2699") // assert not exception is thrown
   public void testRemoveNonExistingRendition() {
-    asset.removeRendition("non-existing");
+    try {
+      asset.removeRendition("non-existing");
+    } catch (Exception e) {
+      fail("removeRendition should not fail on non-existing renditions!");
+    }
   }
 
   @Test

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -112,8 +112,10 @@ public class MockGraniteAssetWrapperTest {
   public void testEquals() {
     Asset asset1 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
     Asset asset2 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
+    Object otherObject = new Object();
 
     assertEquals(asset1, asset2);
+    assertNotEquals(asset1, otherObject);
   }
 
   private void doTestAddRemoveRendition(final String renditionName) {

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapperTest.java
@@ -1,0 +1,131 @@
+package io.wcm.testing.mock.aem.dam;
+
+import com.adobe.granite.asset.api.Asset;
+import com.adobe.granite.asset.api.Rendition;
+import com.day.cq.dam.api.DamEvent;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osgi.service.event.EventHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class MockGraniteAssetWrapperTest {
+
+    private static final byte[] BINARY_DATA = new byte[] {
+            0x01, 0x02, 0x03, 0x04, 0x05
+    };
+
+    @Rule
+    public final AemContext context = TestAemContext.newAemContext();
+
+    private Asset asset;
+    private MockAssetManagerTest.DamEventHandler damEventHandler;
+
+    @Before
+    public void setUp() {
+        context.load().json("/json-import-samples/dam.json", "/content/dam/sample");
+
+        Resource resource = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg");
+        this.asset = resource.adaptTo(Asset.class);
+
+        this.damEventHandler = (MockAssetManagerTest.DamEventHandler) context.registerService(EventHandler.class, new MockAssetManagerTest.DamEventHandler());
+    }
+
+    @Test
+    public void testProperties() {
+        assertEquals("scott_reynolds.jpg", asset.getName());
+        assertEquals("/content/dam/sample/portraits/scott_reynolds.jpg", asset.getPath());
+        assertNotEquals(0, asset.hashCode());
+
+        if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
+            assertNotNull(asset.getIdentifier());
+        }
+        else {
+            assertEquals("442d55b6-d534-4faf-9394-c9c20d095985", asset.getIdentifier());
+        }
+    }
+
+    @Test
+    public void testRenditions() {
+        List<Rendition> renditions = IteratorUtils.toList(asset.listRenditions());
+        assertEquals(4, renditions.size());
+        assertTrue(hasRendition(renditions, "cq5dam.thumbnail.48.48.png"));
+        assertEquals("original", asset.getRendition("original").getName());
+    }
+
+    private boolean hasRendition(List<Rendition> renditions, String renditionName) {
+        for (Rendition rendition : renditions) {
+            if (StringUtils.equals(rendition.getName(), renditionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void testRemoveNonExistingRendition() {
+        asset.removeRendition("non-existing");
+    }
+
+    @Test
+    public void testEquals() {
+        Asset asset1 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
+        Asset asset2 = this.context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg").adaptTo(Asset.class);
+
+        assertEquals(asset1, asset2);
+    }
+
+    private void doTestAddRemoveRendition(final String renditionName) {
+        InputStream is = new ByteArrayInputStream(BINARY_DATA);
+        Rendition rendition = asset.setRendition(renditionName, is, Map.of("jcr:mimeType", "application/octet-stream"));
+
+        assertNotNull(rendition);
+        assertNotNull(asset.getRendition(renditionName));
+        Resource resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
+        assertNotNull(resource);
+
+        Optional<DamEvent> damEvent = damEventHandler.getLastEvent();
+        assertTrue(damEvent.isPresent());
+        assertEquals(DamEvent.Type.RENDITION_UPDATED, damEvent.get().getType());
+        assertEquals(asset.getPath(), damEvent.get().getAssetPath());
+        assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
+
+        asset.removeRendition(renditionName);
+
+        assertNull(asset.getRendition(renditionName));
+        resource = context.resourceResolver().getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/" + renditionName);
+        assertNull(resource);
+
+        damEvent = damEventHandler.getLastEvent();
+        assertTrue(damEvent.isPresent());
+        assertEquals(DamEvent.Type.RENDITION_REMOVED, damEvent.get().getType());
+        assertEquals(asset.getPath(), damEvent.get().getAssetPath());
+        assertEquals(rendition.getPath(), damEvent.get().getAdditionalInfo());
+    }
+
+    @Test
+    public void testAddRemoveRendition() {
+        doTestAddRemoveRendition("test.bin");
+    }
+
+    @Test
+    public void testCQAdaptation() {
+        com.day.cq.dam.api.Asset cqAsset = asset.adaptTo(com.day.cq.dam.api.Asset.class);
+        assertNotNull(cqAsset);
+        assertEquals(asset, cqAsset.adaptTo(Asset.class));
+    }
+
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteRenditionTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteRenditionTest.java
@@ -19,15 +19,19 @@
  */
 package io.wcm.testing.mock.aem.dam;
 
-import com.adobe.granite.asset.api.Rendition;
-import io.wcm.testing.mock.aem.context.TestAemContext;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import com.adobe.granite.asset.api.Rendition;
+
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 @SuppressWarnings("null")
 public class MockGraniteRenditionTest {
@@ -65,7 +69,7 @@ public class MockGraniteRenditionTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void testEquals() {
     Rendition rendition1 = this.context.resourceResolver()
         .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original").adaptTo(Rendition.class);
     Rendition rendition2 = this.context.resourceResolver()

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteRenditionTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockGraniteRenditionTest.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.testing.mock.aem.dam;
+
+import com.adobe.granite.asset.api.Rendition;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("null")
+public class MockGraniteRenditionTest {
+
+  @Rule
+  public AemContext context = TestAemContext.newAemContext();
+
+  private Rendition rendition;
+
+  @Before
+  public void setUp() {
+    context.load().json("/json-import-samples/dam.json", "/content/dam/sample");
+
+    Resource resource = this.context.resourceResolver()
+        .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original");
+    this.rendition = resource.adaptTo(Rendition.class);
+  }
+
+  @Test
+  public void testProperties() {
+    assertEquals("original", rendition.getName());
+    assertEquals("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original", rendition.getPath());
+    assertEquals("image/jpeg", rendition.getMimeType());
+    assertNotEquals(0, rendition.hashCode());
+  }
+
+  @Test
+  public void testStream() {
+    assertNotNull(rendition.getStream());
+  }
+
+  @Test
+  public void testSize() {
+    assertEquals(0L, rendition.getSize());
+  }
+
+  @Test
+  public void testEquals() throws Exception {
+    Rendition rendition1 = this.context.resourceResolver()
+        .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original").adaptTo(Rendition.class);
+    Rendition rendition2 = this.context.resourceResolver()
+        .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original").adaptTo(Rendition.class);
+    Rendition rendition3 = this.context.resourceResolver()
+        .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/cq5dam.thumbnail.48.48.png").adaptTo(Rendition.class);
+
+    assertEquals(rendition1, rendition2);
+    assertNotEquals(rendition1, rendition3);
+  }
+
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockRenditionTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockRenditionTest.java
@@ -22,6 +22,7 @@ package io.wcm.testing.mock.aem.dam;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
@@ -76,7 +77,7 @@ public class MockRenditionTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void testEquals() {
     Rendition rendition1 = this.context.resourceResolver()
         .getResource("/content/dam/sample/portraits/scott_reynolds.jpg/jcr:content/renditions/original").adaptTo(Rendition.class);
     Rendition rendition2 = this.context.resourceResolver()
@@ -86,6 +87,12 @@ public class MockRenditionTest {
 
     assertEquals(rendition1, rendition2);
     assertNotEquals(rendition1, rendition3);
+  }
+
+  @Test
+  public void testAdaptTo() {
+    assertSame(rendition, rendition.adaptTo(Rendition.class));
+    assertSame(rendition, rendition.adaptTo(com.adobe.granite.asset.api.Rendition.class));
   }
 
 }


### PR DESCRIPTION
Even though it's not the recommended API for assets, the Adobe Granite Asset API has some useful methods compared to the Day CQ Asset API (like removeAsset).  

We use it in some projects (especially the removeAsset functionality).

This PR adds mocks for this.

I opted to use wrappers for the existing mocks (`MockAsset` & `MockAssetManager`) instead of re-implementing the same or similar code. `MockRendition` already had the required methods so that was solved by just adding the other interface.