### PR TITLE
changed HashSet to LinkedHashSet to fix flaky test

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update to latest OSGi Mock.
       </action>
+      <action type="fix" dev="Benjamin Guan" issue="52">
+        MockTagManager.getTagsForSubtree: Ensure stable order of result list.
+      </action>
     </release>
 
     <release version="5.6.2" date="2024-09-16">

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockTagManager.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockTagManager.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -377,7 +378,7 @@ public final class MockTagManager implements TagManager {
     if (resource == null) {
       return Collections.emptyList();
     }
-    Set<Tag> treeTags = new HashSet<>();
+    Set<Tag> treeTags = new LinkedHashSet<>();
     Queue<Resource> searchResources = new LinkedList<>();
     searchResources.add(resource);
 


### PR DESCRIPTION
Linked PR / Issue: https://github.com/adobe/aem-core-wcm-components/pull/2894

There is a flaky test in the aem-core-wcm-components project which should be fixed by changing the `HashSet` to a `LinkedHashSet` in the `collectResourceTags` function. 