### PR TITLE
MockAemBindingsValuesProvider: Avoid clash with org.apache.sling.scripting.core 2.4.10

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="5.6.8" date="not released">
+      <action type="update" dev="sseifert">
+        MockAemBindingsValuesProvider: Avoid clash with org.apache.sling.scripting.core 2.4.10 by using a different service property name for passing the AemContext object.
+      </action>
+    </release>
+
     <release version="5.6.6" date="2025-02-10">
       <action type="update" dev="sseifert" issue="53">
         Add dependency to icu4j 74.2 (required by com.day.cq.cq-commons 5.14.14 / AEMaaCS 2025.1.19352.20250131T194709Z-250100).

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="5.6.8" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="54">
         MockAemBindingsValuesProvider: Avoid clash with org.apache.sling.scripting.core 2.4.10 by using a different service property name for passing the AemContext object.
       </action>
     </release>

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -85,7 +85,7 @@ public class AemContextImpl extends SlingContextImpl {
     registerInjectActivateService(new MockAssetStore());
     registerInjectActivateService(new MockPublishUtils());
     registerInjectActivateService(new MockAemBindingsValuesProvider(),
-        MockAemBindingsValuesProvider.PROPERTY_CONTEXT, this);
+        MockAemBindingsValuesProvider.PROPERTY_AEM_CONTEXT_OBJECT, this);
     registerInjectActivateService(new MockPageManagerFactory());
     registerInjectActivateService(new MockLanguageManager());
     registerInjectActivateService(new MockResourceCollectionManager());

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemBindingsValuesProvider.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/MockAemBindingsValuesProvider.java
@@ -43,14 +43,14 @@ import io.wcm.testing.mock.aem.context.MockAemSlingBindings.SlingBindingsPropert
     property = "MockSlingBindings-ignore=true")
 class MockAemBindingsValuesProvider implements BindingsValuesProvider {
 
-  static final String PROPERTY_CONTEXT = "context";
+  static final String PROPERTY_AEM_CONTEXT_OBJECT = "aemContextObject";
 
   @SuppressWarnings("java:S1845") // naming
   private AemContextImpl context;
 
   @Activate
   private void activate(Map<String, Object> config) {
-    this.context = (AemContextImpl)config.get(PROPERTY_CONTEXT);
+    this.context = (AemContextImpl)config.get(PROPERTY_AEM_CONTEXT_OBJECT);
   }
 
   @Deactivate


### PR DESCRIPTION
by using a different service property name for passing the AemContext object.