### PR TITLE
#40 Get rid of ResourceWrapper for com.day.cq.dam.api.Asset

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="5.6.10" date="not released">
+      <action type="update" dev="sseifert" issue="40">
+        MockAsset: Do not extend from ResourceWrapper to not rely on its adaptTo() implementation.
+      </action>
+    </release>
+
     <release version="5.6.8" date="2025-03-05">
       <action type="update" dev="sseifert" issue="54">
         MockAemBindingsValuesProvider: Avoid clash with org.apache.sling.scripting.core 2.4.10 by using a different service property name for passing the AemContext object.

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAemDamAdapterFactory.java
@@ -77,7 +77,7 @@ public final class MockAemDamAdapterFactory implements AdapterFactory {
   private @Nullable <AdapterType> AdapterType getAdapter(@NotNull final Resource resource, @NotNull final Class<AdapterType> type) {
     if (DamUtil.isAsset(resource)) {
       if (type == com.adobe.granite.asset.api.Asset.class) {
-        return type.cast(new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext)));
+        return type.cast(new MockGraniteAssetWrapper(new MockAsset(resource, eventAdmin, bundleContext), resource));
       }
       else if (type == Asset.class) {
         return type.cast(new MockAsset(resource, eventAdmin, bundleContext));

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockAsset.java
@@ -32,11 +32,11 @@ import javax.jcr.Binary;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.security.user.User;
+import org.apache.sling.api.adapter.SlingAdaptable;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.resource.ResourceWrapper;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
 import org.jetbrains.annotations.NotNull;
@@ -59,10 +59,10 @@ import com.day.cq.dam.api.Revision;
     "null",
     "java:S112" // allow throwing RuntimException
 })
-class MockAsset extends ResourceWrapper implements Asset {
+class MockAsset extends SlingAdaptable implements Asset {
 
   private final ResourceResolver resourceResolver;
-  private final Resource resource;
+  protected final Resource resource;
   private final ValueMap contentProps;
   private final Resource renditionsResource;
   private final EventAdmin eventAdmin;
@@ -70,7 +70,6 @@ class MockAsset extends ResourceWrapper implements Asset {
   private boolean batchMode;
 
   MockAsset(@NotNull Resource resource, EventAdmin eventAdmin, BundleContext bundleContext) {
-    super(resource);
     this.resourceResolver = resource.getResourceResolver();
     this.resource = resource;
     Resource contentResource = resource.getChild(JcrConstants.JCR_CONTENT);
@@ -81,13 +80,13 @@ class MockAsset extends ResourceWrapper implements Asset {
   }
 
   @Override
-  public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+  public <AdapterType> AdapterType adaptTo(@NotNull Class<AdapterType> type) {
     if (type == Resource.class) {
       return type.cast(resource);
     }
     //to be able to adapt to granite asset
     if (type == com.adobe.granite.asset.api.Asset.class) {
-      return type.cast(new MockGraniteAssetWrapper(this));
+      return type.cast(new MockGraniteAssetWrapper(this, resource));
     }
     return super.adaptTo(type);
   }
@@ -101,6 +100,16 @@ class MockAsset extends ResourceWrapper implements Asset {
   @Override
   public Object getMetadata(String name) {
     return getMetadata().get(name);
+  }
+
+  @Override
+  public String getPath() {
+    return resource.getPath();
+  }
+
+  @Override
+  public String getName() {
+    return resource.getName();
   }
 
   @Override

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetManagerWrapper.java
@@ -48,7 +48,7 @@ public final class MockGraniteAssetManagerWrapper implements AssetManager {
   @Override
   public Asset createAsset(String s) {
     com.day.cq.dam.api.Asset asset = cqAssetManager.createAsset(s, null, null, false);
-    return new MockGraniteAssetWrapper(asset);
+    return new MockGraniteAssetWrapper(asset, ((MockAsset)asset).resource);
   }
 
   @Override

--- a/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/dam/MockGraniteAssetWrapper.java
@@ -47,8 +47,8 @@ public final class MockGraniteAssetWrapper extends ResourceWrapper implements As
   private final com.day.cq.dam.api.Asset asset;
 
   @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // adaption to Resource will always work
-  MockGraniteAssetWrapper(com.day.cq.dam.api.Asset asset) {
-    super(asset.adaptTo(Resource.class));
+  MockGraniteAssetWrapper(com.day.cq.dam.api.Asset asset, Resource resource) {
+    super(resource);
     this.asset = asset;
   }
 

--- a/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/dam/MockAssetTest.java
@@ -229,8 +229,6 @@ public class MockAssetTest {
 
   @Test
   public void testAdaptTo() {
-    assertSame(asset, asset.adaptTo(Asset.class));
     assertSame(asset, asset.adaptTo(com.adobe.granite.asset.api.Asset.class).adaptTo(Asset.class));
   }
-
 }


### PR DESCRIPTION
which was using an incorrect adaptTo() implementation (causing the Resource to be used, instead of the Asset itself, as the source of the adaption)

Fixes #40 