### PR TITLE
#82 MockPage: Don't throw NPE when requesting a deep content resource…

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
-
+    <release version="5.6.14" date="unreleased">
+      <action type="fix" dev="henrykuijpers" issue="82">
+        MockPage: Don't throw NPE when requesting a deep content resource when the content resource itself is absent.
+      </action>
+    </release>
     <release version="5.6.12" date="2025-11-21">
       <action type="update" dev="sseifert">
         Update to latest Sling Mock 3.x, JCR Mock, OSGi Mock.

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockPage.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockPage.java
@@ -67,12 +67,7 @@ class MockPage extends SlingAdaptable implements Page {
     this.resource = resource;
     this.contentResource = this.resource.getChild(JcrConstants.JCR_CONTENT);
     this.resourceResolver = resource.getResourceResolver();
-    if (this.contentResource != null) {
-      this.properties = this.contentResource.getValueMap();
-    }
-    else {
-      this.properties = ValueMap.EMPTY;
-    }
+    this.properties = ResourceUtil.getValueMap(this.contentResource);
   }
 
   @Override
@@ -117,6 +112,9 @@ class MockPage extends SlingAdaptable implements Page {
 
   @Override
   public Resource getContentResource(final String relPath) {
+    if (this.contentResource == null) {
+      return null;
+    }
     return this.contentResource.getChild(relPath);
   }
 

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockPageTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockPageTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -153,6 +154,15 @@ public class MockPageTest {
     assertNotNull(this.page.getContentResource("par"));
     assertNull(this.page.getContentResource("nonExistingResource"));
     assertTrue(this.page.hasContent());
+  }
+
+  @Test
+  public void testContentResourceAbsence() {
+    final Resource resource = context.create().resource("/content/sample/en/absence", "jcr:primaryType", "cq:Page");
+    final Page absencePage = Objects.requireNonNull(resource.adaptTo(Page.class));
+    assertNull(absencePage.getContentResource());
+    assertNull(absencePage.getContentResource("par"));
+    assertNull(absencePage.getContentResource("par/image"));
   }
 
   @Test


### PR DESCRIPTION
… when the content resource itself is absent

Fixes #82 