### PR TITLE
#86 MockDesigner/MockDesign improvements

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,27 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="unreleased" date="2026-02-03">
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockDesigner/MockDesign: Support the creation of designs in ContentBuilder.
+      </action>
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockDesigner: Add designer-method in AemContextImpl.
+      </action>
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockStyle: Simplify implementation by using ValueMapDecorator.
+      </action>
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockDesigner: Implement getting designs and fallbacks to the default designs. Support legacy designs.
+      </action>
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockDesign: Implement MockDesign#getContentResource + MockDesign#getId() + MockDesign#getJSON.
+      </action>
+      <action type="update" dev="henrykuijpers" issue="86">
+        MockAemAdapterFactory: Support getting a Design from a Resource.
+      </action>
+    </release>
+
     <release version="5.6.14" date="2025-12-15">
       <action type="fix" dev="henrykuijpers" issue="82">
         MockPage: Don't throw NPE when requesting a deep content resource when the content resource itself is absent.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="unreleased" date="2026-02-03">
+    <release version="5.6.16" date="not released">
       <action type="update" dev="henrykuijpers" issue="86">
         MockDesigner/MockDesign: Support the creation of designs in ContentBuilder.
       </action>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -294,6 +294,12 @@
       <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.3</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockAemAdapterFactory.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockAemAdapterFactory.java
@@ -30,6 +30,7 @@ import static io.wcm.testing.mock.aem.MockContentPolicyStorage.RT_CONTENT_POLICY
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
+import com.day.cq.wcm.api.designer.Design;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
@@ -68,6 +69,7 @@ import com.day.cq.wcm.api.policies.ContentPolicyMapping;
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.tagging.TagManager",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.tagging.Tag",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.wcm.api.designer.Designer",
+        AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.wcm.api.designer.Design",
         AdapterFactory.ADAPTER_CLASSES + "=com.adobe.cq.dam.cfm.ContentFragment",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.wcm.api.policies.ContentPolicy",
         AdapterFactory.ADAPTER_CLASSES + "=com.day.cq.wcm.api.policies.ContentPolicyMapping",
@@ -103,6 +105,9 @@ public final class MockAemAdapterFactory implements AdapterFactory {
     }
     if (type == ContentPolicy.class && resource.isResourceType(RT_CONTENTPOLICY)) {
       return (AdapterType)new MockContentPolicy(resource);
+    }
+    if (type == Design.class && isPrimaryType(resource, Designer.NT_DESIGN)) {
+      return (AdapterType)new MockDesign(resource);
     }
     if (type == ContentPolicyMapping.class
         && (resource.isResourceType(RT_CONTENT_POLICY_MAPPING) || resource.isResourceType(RT_CONTENT_POLICY_MAPPINGS))

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
@@ -21,42 +21,57 @@ package io.wcm.testing.mock.aem;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.jcr.RepositoryException;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
 import javax.servlet.jsp.PageContext;
 
+import com.day.cq.commons.jcr.JcrConstants;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 
 import com.day.cq.wcm.api.designer.Cell;
 import com.day.cq.wcm.api.designer.ComponentStyle;
 import com.day.cq.wcm.api.designer.Design;
-import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.api.policies.ContentPolicy;
 import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of {@link Design}.
  */
 class MockDesign implements Design {
 
-  private final Style emptyStyle = new MockStyle(ValueMap.EMPTY, this);
-  private final ResourceResolver resourceResolver;
+  private static final Set<String> JSON_EXCLUDE_PROPERTY_NAMES = Set.of(
+          JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY,
+          JcrConstants.JCR_PRIMARYTYPE,
+          JcrConstants.JCR_MIXINTYPES
+  );
 
-  MockDesign(ResourceResolver resourceResolver) {
-    this.resourceResolver = resourceResolver;
+  private static final SimpleDateFormat JSON_DATE_FORMAT = new SimpleDateFormat("EEE MMM dd yyyy HH:mm:ss 'GMT'Z",Locale.US);
+
+  private final Style emptyStyle = new MockStyle(ValueMap.EMPTY, this);
+  private final Resource resource;
+
+  MockDesign(@NotNull Resource resource) {
+    this.resource = resource;
   }
 
   @Override
   public Style getStyle(String path) {
-    Resource resource = resourceResolver.getResource(path);
-    if (resource != null) {
-      return getStyle(resource);
+    Resource styleResource = this.resource.getResourceResolver().getResource(path);
+    if (styleResource != null) {
+      return getStyle(styleResource);
     }
     return emptyStyle;
   }
@@ -64,8 +79,8 @@ class MockDesign implements Design {
   @Override
   public Style getStyle(Cell cell) {
     if (cell instanceof MockCell) {
-      Resource resource = ((MockCell)cell).getComponentContext().getResource();
-      return getStyle(resource);
+      Resource styleResource = ((MockCell)cell).getComponentContext().getResource();
+      return getStyle(styleResource);
     }
     return emptyStyle;
   }
@@ -90,9 +105,8 @@ class MockDesign implements Design {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public String getPath() {
-    return Designer.DEFAULT_DESIGN_PATH;
+    return resource.getPath();
   }
 
 
@@ -105,7 +119,7 @@ class MockDesign implements Design {
 
   @Override
   public Resource getContentResource() {
-    throw new UnsupportedOperationException();
+    return this.resource.getChild(JcrConstants.JCR_CONTENT);
   }
 
   @Override
@@ -121,12 +135,17 @@ class MockDesign implements Design {
 
   @Override
   public String getId() {
-    throw new UnsupportedOperationException();
+    return StringUtils.removeStart(resource.getPath(), MockDesigner.LEGACY_DESIGNS_PATH_PREFIX);
   }
 
   @Override
   public String getJSON() {
-    throw new UnsupportedOperationException();
+    final JsonObjectBuilder builder = Json.createObjectBuilder();
+    final Resource contentResource = this.getContentResource();
+    if (contentResource != null) {
+      addSafePropertiesToJson(builder, contentResource);
+    }
+    return builder.build().toString();
   }
 
   @Override
@@ -165,4 +184,30 @@ class MockDesign implements Design {
     throw new UnsupportedOperationException();
   }
 
+  private static void addSafePropertiesToJson(@NotNull final JsonObjectBuilder builder, @NotNull final Resource resource) {
+    resource.getValueMap().forEach((key, value) -> {
+      if (JSON_EXCLUDE_PROPERTY_NAMES.contains(key)) {
+        return;
+      }
+      if (value instanceof String) {
+        builder.add(key, (String) value);
+      } else if (value instanceof Long) {
+        builder.add(key, (long) value);
+      } else if (value instanceof Integer) {
+        builder.add(key, (int) value);
+      } else if (value instanceof Boolean) {
+        builder.add(key, (boolean) value);
+      } else if (value instanceof Calendar) {
+        builder.add(key, JSON_DATE_FORMAT.format(((Calendar) value).getTime()));
+      } else {
+        throw new RuntimeException("Unrecognized property value of type " + value.getClass());
+      }
+    });
+
+    resource.getChildren().forEach(child -> {
+      final JsonObjectBuilder subObject = Json.createObjectBuilder();
+      addSafePropertiesToJson(subObject, child);
+      builder.add(child.getName(), subObject);
+    });
+  }
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
@@ -21,7 +21,7 @@ package io.wcm.testing.mock.aem;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Map;
@@ -58,7 +58,7 @@ class MockDesign implements Design {
           JcrConstants.JCR_MIXINTYPES
   );
 
-  private static final SimpleDateFormat JSON_DATE_FORMAT = new SimpleDateFormat("EEE MMM dd yyyy HH:mm:ss 'GMT'Z",Locale.US);
+  private static final DateTimeFormatter JSON_DATE_FORMAT = DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z", Locale.US);
 
   private final Style emptyStyle = new MockStyle(ValueMap.EMPTY, this);
   private final Resource resource;
@@ -198,7 +198,8 @@ class MockDesign implements Design {
       } else if (value instanceof Boolean) {
         builder.add(key, (boolean) value);
       } else if (value instanceof Calendar) {
-        builder.add(key, JSON_DATE_FORMAT.format(((Calendar) value).getTime()));
+        final Calendar calendar = (Calendar) value;
+        builder.add(key, JSON_DATE_FORMAT.format(calendar.toInstant().atZone(calendar.getTimeZone().toZoneId())));
       } else {
         throw new RuntimeException("Unrecognized property value of type " + value.getClass());
       }

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
@@ -32,20 +32,20 @@ import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import javax.servlet.jsp.PageContext;
 
-import com.day.cq.commons.jcr.JcrConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.jetbrains.annotations.NotNull;
 
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.designer.Cell;
 import com.day.cq.wcm.api.designer.ComponentStyle;
 import com.day.cq.wcm.api.designer.Design;
 import com.day.cq.wcm.api.designer.Style;
 import com.day.cq.wcm.api.policies.ContentPolicy;
 import com.day.cq.wcm.api.policies.ContentPolicyManager;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Mock implementation of {@link Design}.
@@ -86,11 +86,11 @@ class MockDesign implements Design {
   }
 
   @Override
-  public Style getStyle(Resource resource) {
-    ContentPolicyManager contentPolicyManager = resource.getResourceResolver().adaptTo(ContentPolicyManager.class);
+  public Style getStyle(Resource res) {
+    ContentPolicyManager contentPolicyManager = res.getResourceResolver().adaptTo(ContentPolicyManager.class);
     if (contentPolicyManager instanceof MockContentPolicyManager) {
       // unwrap resource to make sure the correct resource type is used when using resource-type forcing wrappers
-      Resource unwrappedResource = ResourceUtil.unwrap(resource);
+      Resource unwrappedResource = ResourceUtil.unwrap(res);
       ContentPolicy policy = ((MockContentPolicyManager)contentPolicyManager).getPolicy(unwrappedResource);
       if (policy != null) {
         return new MockStyle(policy.getProperties(), this);
@@ -100,8 +100,8 @@ class MockDesign implements Design {
   }
 
   @Override
-  public Style getStyle(Resource resource, boolean ignoreExcludedComponents) {
-    return getStyle(resource);
+  public Style getStyle(Resource res, boolean ignoreExcludedComponents) {
+    return getStyle(res);
   }
 
   @Override
@@ -190,15 +190,15 @@ class MockDesign implements Design {
         return;
       }
       if (value instanceof String) {
-        builder.add(key, (String) value);
+        builder.add(key, (String)value);
       } else if (value instanceof Long) {
-        builder.add(key, (long) value);
+        builder.add(key, (long)value);
       } else if (value instanceof Integer) {
-        builder.add(key, (int) value);
+        builder.add(key, (int)value);
       } else if (value instanceof Boolean) {
-        builder.add(key, (boolean) value);
+        builder.add(key, (boolean)value);
       } else if (value instanceof Calendar) {
-        final Calendar calendar = (Calendar) value;
+        final Calendar calendar = (Calendar)value;
         builder.add(key, JSON_DATE_FORMAT.format(calendar.toInstant().atZone(calendar.getTimeZone().toZoneId())));
       } else {
         throw new RuntimeException("Unrecognized property value of type " + value.getClass());

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesigner.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesigner.java
@@ -19,6 +19,12 @@
  */
 package io.wcm.testing.mock.aem;
 
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.commons.WCMUtils;
+import com.day.text.Text;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
@@ -27,11 +33,33 @@ import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.designer.Design;
 import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.designer.Style;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Mock implementation of {@link Designer}.
  */
 class MockDesigner implements Designer {
+  private static final Logger log = LoggerFactory.getLogger(MockDesigner.class);
+
+  @SuppressWarnings({"java:S1075","deprecation"}) // Repository path
+  static final String LEGACY_DEFAULT_DESIGN_PATH = DEFAULT_DESIGN_PATH;
+  static final String LEGACY_DESIGNS_PATH_PREFIX = StringUtils.substringBeforeLast(LEGACY_DEFAULT_DESIGN_PATH, String.valueOf('/')) + '/';
+
+  @SuppressWarnings("java:S1075") // Repository path
+  static final String LIBS_DEFAULT_DESIGN_PATH = "/libs/settings/wcm/designs/default";
+
+  static final Set<String> DEFAULT_DESIGN_PATHS = new LinkedHashSet<>();
+
+  static {
+    DEFAULT_DESIGN_PATHS.add(LEGACY_DEFAULT_DESIGN_PATH);
+    DEFAULT_DESIGN_PATHS.add(LIBS_DEFAULT_DESIGN_PATH);
+  }
 
   private final ResourceResolver resourceResolver;
 
@@ -41,46 +69,84 @@ class MockDesigner implements Designer {
 
   @Override
   public String getDesignPath(Page page) {
-    return null;
+    if (page == null) {
+      return null;
+    }
+    final String path = WCMUtils.getInheritedProperty(page, resourceResolver, NameConstants.PN_DESIGN_PATH);
+    if (path != null) {
+      return path;
+    }
+    if (resourceResolver.getResource(LEGACY_DEFAULT_DESIGN_PATH) != null) {
+      return LEGACY_DEFAULT_DESIGN_PATH;
+    }
+    return LIBS_DEFAULT_DESIGN_PATH;
   }
 
   @Override
   public Design getDesign(Page page) {
-    return getDefaultDesign();
+    if (page == null) {
+      return null;
+    }
+    final String designPath = getDesignPath(page);
+    if (designPath == null) {
+      return getDefaultDesign();
+    }
+    return getDesign(designPath);
   }
 
   @Override
   public boolean hasDesign(String id) {
-    return true;
+    final Design design = getDesign(idToPath(id));
+    return !DEFAULT_DESIGN_PATHS.contains(design.getPath());
   }
 
   @Override
   public Design getDesign(String id) {
+    final String path = idToPath(id);
+    final Resource resource = resourceResolver.getResource(path);
+    if (resource != null) {
+      return new MockDesign(resource);
+    }
+    if (!DEFAULT_DESIGN_PATHS.contains(path)) {
+      log.warn("Design with path {} not found, returning the default design", path);
+    }
     return getDefaultDesign();
   }
 
   @Override
   public Style getStyle(Resource resource) {
-    if (resource != null) {
-      PageManager pageManager = resource.getResourceResolver().adaptTo(PageManager.class);
-      if (pageManager != null) {
-        Page page = pageManager.getContainingPage(resource);
-        if (page != null) {
-          return getDesign(page).getStyle(resource);
-        }
+    return getStyle(resource, null);
+  }
+
+  @Override
+  public Style getStyle(Resource resource, String cellPath) {
+    final PageManager pageManager = Objects.requireNonNull(resourceResolver.adaptTo(PageManager.class));
+    final Page page = pageManager.getContainingPage(resource);
+    if (page != null) {
+      final Design design = this.getDesign(page);
+      if (design != null) {
+        return design.getStyle(cellPath == null ? Text.getName(resource.getPath()) : cellPath);
       }
     }
     return null;
   }
 
   @Override
-  public Style getStyle(Resource resource, String cellPath) {
-    return getStyle(resource);
-  }
-
-  @Override
   public Design getDefaultDesign() {
-    return new MockDesign(resourceResolver);
+    for (final String path : DEFAULT_DESIGN_PATHS) {
+      final Resource designResource = resourceResolver.getResource(path);
+      if (designResource != null) {
+        return new MockDesign(designResource);
+      }
+    }
+    return new MockDesign(new NonExistingResource(resourceResolver, LIBS_DEFAULT_DESIGN_PATH));
   }
 
+  @NotNull
+  private String idToPath(@NotNull final String id) {
+    if (StringUtils.startsWithAny(id, ArrayUtils.add(resourceResolver.getSearchPath(), "/conf/"))) {
+      return id;
+    }
+    return LEGACY_DESIGNS_PATH_PREFIX + StringUtils.removeStart(StringUtils.removeStart(id, LEGACY_DESIGNS_PATH_PREFIX), String.valueOf('/'));
+  }
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockStyle.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockStyle.java
@@ -19,12 +19,9 @@
  */
 package io.wcm.testing.mock.aem;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,9 +32,9 @@ import com.day.cq.wcm.api.designer.Style;
 /**
  * Mock implementation of {@link Style}.
  */
-class MockStyle implements Style {
+@SuppressWarnings("squid:S2160") // Not extending the equals implementation
+class MockStyle extends ValueMapDecorator implements Style {
 
-  private final ValueMap props;
   private final Design design;
 
   /**
@@ -45,107 +42,14 @@ class MockStyle implements Style {
    * @param design Design
    */
   MockStyle(@NotNull ValueMap props, @Nullable Design design) {
-    this.props = props;
+    super(props);
     this.design = design;
-  }
-
-  /**
-   * @param props Value map for style properties
-   */
-  MockStyle(@NotNull ValueMap props) {
-    this(props, (Design)null);
   }
 
   @Override
   public Design getDesign() {
     return design;
   }
-
-
-  // --- delegate methods to ValueMap ---
-
-  @Override
-  @SuppressWarnings("null")
-  public <T> T get(String name, Class<T> type) {
-    return this.props.get(name, type);
-  }
-
-  @Override
-  @SuppressWarnings("null")
-  public <T> T get(String name, T defaultValue) {
-    return this.props.get(name, defaultValue);
-  }
-
-  @Override
-  public int size() {
-    return this.props.size();
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return this.props.isEmpty();
-  }
-
-  @Override
-  public boolean containsKey(Object key) {
-    return this.props.containsKey(key);
-  }
-
-  @Override
-  public boolean containsValue(Object value) {
-    return this.props.containsValue(value);
-  }
-
-  @Override
-  public Object get(Object key) {
-    return this.props.get(key);
-  }
-
-  @Override
-  public Object put(String key, Object value) {
-    return this.props.put(key, value);
-  }
-
-  @Override
-  public Object remove(Object key) {
-    return this.props.remove(key);
-  }
-
-  @Override
-  public void putAll(Map<? extends String, ? extends Object> m) {
-    this.props.putAll(m);
-  }
-
-  @Override
-  public void clear() {
-    this.props.clear();
-  }
-
-  @Override
-  public Set<String> keySet() {
-    return this.props.keySet();
-  }
-
-  @Override
-  public Collection<Object> values() {
-    return this.props.values();
-  }
-
-  @Override
-  public Set<Entry<String, Object>> entrySet() {
-    return this.props.entrySet();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    return this.props.equals(o);
-  }
-
-  @Override
-  public int hashCode() {
-    return this.props.hashCode();
-  }
-
 
   // --- unsupported operations ---
 

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockStyle.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockStyle.java
@@ -29,10 +29,13 @@ import com.day.cq.wcm.api.designer.Cell;
 import com.day.cq.wcm.api.designer.Design;
 import com.day.cq.wcm.api.designer.Style;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Mock implementation of {@link Style}.
  */
-@SuppressWarnings("squid:S2160") // Not extending the equals implementation
+@SuppressWarnings({ "squid:S2160", "null" }) // Not extending the equals implementation
+@SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 class MockStyle extends ValueMapDecorator implements Style {
 
   private final Design design;

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
@@ -663,6 +663,18 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
    * @param properties Properties for the design resource
    * @return Design object
    */
+  public @NotNull Design design(@NotNull final String path, @NotNull final String title, @NotNull Map<String, Object> properties) {
+    Map<String, Object> updatedProperties = new HashMap<>(properties);
+    updatedProperties.put(JcrConstants.JCR_TITLE, title);
+    return design(path, updatedProperties);
+  }
+
+  /**
+   * Create a design page.
+   * @param path Path of the design resource
+   * @param properties Properties for the design resource
+   * @return Design object
+   */
   public @NotNull Design design(@NotNull final String path, @NotNull final String title, @NotNull Object @NotNull... properties) {
     return design(path, ArrayUtils.addAll(properties, JcrConstants.JCR_TITLE, title));
   }
@@ -673,15 +685,21 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
    * @param properties Properties for the design resource
    * @return Design object
    */
-  public @NotNull Design design(@NotNull final String path, @NotNull Object @NotNull... properties) {
-    final Map<String, Object> propsMap;
-    if (properties.length > 0) {
-      propsMap = MapUtil.toMap(properties);
-    } else {
-      propsMap = new HashMap<>();
-    }
+  public @NotNull Design design(@NotNull final String path, @NotNull Map<String, Object> properties) {
+    final Map<String, Object> propsMap = new HashMap<>(properties);
     propsMap.putIfAbsent(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "wcm/core/components/designer");
     final Page page = page(path, null, propsMap);
     return Objects.requireNonNull(Objects.requireNonNull(page.adaptTo(Resource.class)).adaptTo(Design.class));
   }
+
+  /**
+   * Create a design page.
+   * @param path Path of the design resource
+   * @param properties Properties for the design resource
+   * @return Design object
+   */
+  public @NotNull Design design(@NotNull final String path, @NotNull Object @NotNull... properties) {
+    return design(path, MapUtil.toMap(properties));
+  }
+
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
@@ -30,7 +30,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessControlException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import com.day.cq.wcm.api.designer.Design;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
@@ -38,6 +41,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.testing.mock.osgi.MapUtil;
 import org.apache.sling.testing.mock.sling.builder.ImmutableValueMap;
 import org.apache.sling.testing.mock.sling.loader.ContentLoader;
@@ -653,4 +657,19 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
     return resource(page, name, MapUtil.toMap(properties));
   }
 
+  public @NotNull Design design(@NotNull final String path, @NotNull final String title, @NotNull Object @NotNull... properties) {
+    return design(path, ArrayUtils.addAll(properties, JcrConstants.JCR_TITLE, title));
+  }
+
+  public @NotNull Design design(@NotNull final String path, @NotNull Object @NotNull... properties) {
+    final Map<String, Object> propsMap;
+    if (properties.length > 0) {
+      propsMap = MapUtil.toMap(properties);
+    } else {
+      propsMap = new HashMap<>();
+    }
+    propsMap.putIfAbsent(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "wcm/core/components/designer");
+    final Page page = page(path, null, propsMap);
+    return Objects.requireNonNull(Objects.requireNonNull(page.adaptTo(Resource.class)).adaptTo(Design.class));
+  }
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.day.cq.wcm.api.designer.Design;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -64,6 +63,7 @@ import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.WCMException;
+import com.day.cq.wcm.api.designer.Design;
 import com.day.image.Layer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -657,10 +657,22 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
     return resource(page, name, MapUtil.toMap(properties));
   }
 
+  /**
+   * Create a design page.
+   * @param path Path of the design resource
+   * @param properties Properties for the design resource
+   * @return Design object
+   */
   public @NotNull Design design(@NotNull final String path, @NotNull final String title, @NotNull Object @NotNull... properties) {
     return design(path, ArrayUtils.addAll(properties, JcrConstants.JCR_TITLE, title));
   }
 
+  /**
+   * Create a design page.
+   * @param path Path of the design resource
+   * @param properties Properties for the design resource
+   * @return Design object
+   */
   public @NotNull Design design(@NotNull final String path, @NotNull Object @NotNull... properties) {
     final Map<String, Object> propsMap;
     if (properties.length > 0) {

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/package-info.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Content builder for creating test content.
  */
-@org.osgi.annotation.versioning.Version("2.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package io.wcm.testing.mock.aem.builder;

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.day.cq.wcm.api.designer.Designer;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -39,6 +38,7 @@ import com.day.cq.dam.api.AssetManager;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.api.designer.Designer;
 import com.day.cq.wcm.api.policies.ContentPolicyMapping;
 import com.day.cq.wcm.commons.WCMUtils;
 
@@ -171,6 +171,9 @@ public class AemContextImpl extends SlingContextImpl {
     return pageManager;
   }
 
+  /**
+   * @return Designer
+   */
   public @NotNull Designer designer() {
     Designer designer = resourceResolver().adaptTo(Designer.class);
     if (designer == null) {

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/AemContextImpl.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.day.cq.wcm.api.designer.Designer;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -168,6 +169,14 @@ public class AemContextImpl extends SlingContextImpl {
       throw new RuntimeException("No page manager.");
     }
     return pageManager;
+  }
+
+  public @NotNull Designer designer() {
+    Designer designer = resourceResolver().adaptTo(Designer.class);
+    if (designer == null) {
+      throw new RuntimeException("No designer.");
+    }
+    return designer;
   }
 
   /**

--- a/core/src/main/java/io/wcm/testing/mock/aem/context/package-info.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/context/package-info.java
@@ -20,5 +20,5 @@
 /**
  * AEM context implementation for unit tests.
  */
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package io.wcm.testing.mock.aem.context;

--- a/core/src/main/java/io/wcm/testing/mock/aem/package-info.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Mock implementation of selected AEM APIs.
  */
-@org.osgi.annotation.versioning.Version("2.3.0")
+@org.osgi.annotation.versioning.Version("2.3.1")
 package io.wcm.testing.mock.aem;

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
@@ -1,0 +1,92 @@
+package io.wcm.testing.mock.aem;
+
+import com.day.cq.wcm.api.designer.Design;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+import org.skyscreamer.jsonassert.comparator.DefaultComparator;
+
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import java.util.Calendar;
+import java.util.Set;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class MockDesignTest {
+
+    @Rule
+    public AemContext context = TestAemContext.newAemContext();
+
+    @Test
+    public void legacyDesign() {
+        final Design design = context.create().design("/apps/settings/designs/test");
+        assertEquals("/apps/settings/designs/test", design.getId());
+        assertEquals("/apps/settings/designs/test", design.getPath());
+    }
+
+    @Test
+    public void design() {
+        final Design design = context.create().design("/etc/designs/test");
+        assertEquals("test", design.getId());
+        assertEquals("/etc/designs/test", design.getPath());
+    }
+
+    @Test
+    public void getJSON() throws JSONException {
+        final Calendar dateProp = Calendar.getInstance();
+        dateProp.setTimeZone(TimeZone.getTimeZone("Europe/Amsterdam"));
+        dateProp.setTimeInMillis(1383430039843L);
+        final Calendar dateProp2 = Calendar.getInstance();
+        dateProp2.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateProp2.setTimeInMillis(1253410638984L);
+        final Design design = context.create().design("/etc/designs/test", "Test",
+                "a", true,
+                "b", 10L,
+                "c", "test",
+                "d", 100,
+                "e", dateProp,
+                "f", dateProp2);
+        final JsonObjectBuilder expectedJson = Json
+                .createObjectBuilder()
+                .add("a", true)
+                .add("b", 10)
+                .add("c", "test")
+                .add("d", 100)
+                .add("e", "Sat Nov 02 2013 23:07:19 GMT+0100")
+                .add("f", "Sun Sep 20 2009 03:37:18 GMT+0200")
+                .add("jcr:title", "Test");
+        if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
+            expectedJson
+                    .add("jcr:created", "<value-ignored>")
+                    .add("jcr:createdBy", "admin");
+        }
+        JSONAssert.assertEquals(expectedJson.build().toString(), design.getJSON(),
+                new IgnoringFieldsComparator(JSONCompareMode.STRICT, "jcr:created"));
+    }
+
+    private static class IgnoringFieldsComparator extends DefaultComparator {
+        @NotNull
+        private final Set<String> ignoredFields;
+
+        public IgnoringFieldsComparator(@NotNull final JSONCompareMode mode, @NotNull final String... ignoredFields) {
+            super(mode);
+            this.ignoredFields = Set.of(ignoredFields);
+        }
+
+        @Override
+        public void compareValues(final String prefix, final Object expectedValue, final Object actualValue, final JSONCompareResult result) throws JSONException {
+            if (!ignoredFields.contains(prefix)) {
+                super.compareValues(prefix, expectedValue, actualValue, result);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
@@ -1,8 +1,14 @@
 package io.wcm.testing.mock.aem;
 
-import com.day.cq.wcm.api.designer.Design;
-import io.wcm.testing.mock.aem.context.TestAemContext;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+import java.util.Set;
+import java.util.TimeZone;
+
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -13,13 +19,10 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
 import org.skyscreamer.jsonassert.comparator.DefaultComparator;
 
-import javax.json.Json;
-import javax.json.JsonObjectBuilder;
-import java.util.Calendar;
-import java.util.Set;
-import java.util.TimeZone;
+import com.day.cq.wcm.api.designer.Design;
 
-import static org.junit.Assert.assertEquals;
+import io.wcm.testing.mock.aem.context.TestAemContext;
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 public class MockDesignTest {
 
@@ -73,7 +76,7 @@ public class MockDesignTest {
         @NotNull
         private final Set<String> ignoredFields;
 
-        public IgnoringFieldsComparator(@NotNull final JSONCompareMode mode, @NotNull final String... ignoredFields) {
+        IgnoringFieldsComparator(@NotNull final JSONCompareMode mode, @NotNull final String... ignoredFields) {
             super(mode);
             this.ignoredFields = Set.of(ignoredFields);
         }

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
@@ -42,12 +42,8 @@ public class MockDesignTest {
 
     @Test
     public void getJSON() throws JSONException {
-        final Calendar dateProp = Calendar.getInstance();
-        dateProp.setTimeZone(TimeZone.getTimeZone("Europe/Amsterdam"));
-        dateProp.setTimeInMillis(1383430039843L);
-        final Calendar dateProp2 = Calendar.getInstance();
-        dateProp2.setTimeZone(TimeZone.getTimeZone("UTC"));
-        dateProp2.setTimeInMillis(1253410638984L);
+        final Calendar dateProp = getCalendar("Europe/Amsterdam", 1383430039843L);
+        final Calendar dateProp2 = getCalendar("UTC", 1253410638984L);
         final Design design = context.create().design("/etc/designs/test", "Test",
                 "a", true,
                 "b", 10L,
@@ -62,7 +58,7 @@ public class MockDesignTest {
                 .add("c", "test")
                 .add("d", 100)
                 .add("e", "Sat Nov 02 2013 23:07:19 GMT+0100")
-                .add("f", "Sun Sep 20 2009 03:37:18 GMT+0200")
+                .add("f", "Sun Sep 20 2009 01:37:18 GMT+0000")
                 .add("jcr:title", "Test");
         if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
             expectedJson
@@ -88,5 +84,12 @@ public class MockDesignTest {
                 super.compareValues(prefix, expectedValue, actualValue, result);
             }
         }
+    }
+
+    @NotNull
+    private static Calendar getCalendar(@NotNull final String zoneId, final long millis) {
+        final Calendar c1 = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
+        c1.setTimeInMillis(millis);
+        return c1;
     }
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
@@ -26,73 +26,75 @@ import io.wcm.testing.mock.aem.junit.AemContext;
 
 public class MockDesignTest {
 
-    @Rule
-    public AemContext context = TestAemContext.newAemContext();
+  @Rule
+  public AemContext context = TestAemContext.newAemContext();
 
-    @Test
-    public void legacyDesign() {
-        final Design design = context.create().design("/apps/settings/designs/test");
-        assertEquals("/apps/settings/designs/test", design.getId());
-        assertEquals("/apps/settings/designs/test", design.getPath());
+  @Test
+  public void legacyDesign() {
+    final Design design = context.create().design("/apps/settings/designs/test");
+    assertEquals("/apps/settings/designs/test", design.getId());
+    assertEquals("/apps/settings/designs/test", design.getPath());
+  }
+
+  @Test
+  public void design() {
+    final Design design = context.create().design("/etc/designs/test");
+    assertEquals("test", design.getId());
+    assertEquals("/etc/designs/test", design.getPath());
+  }
+
+  @Test
+  public void getJSON() throws JSONException {
+    final Calendar dateProp = getCalendar("Europe/Amsterdam", 1383430039843L);
+    final Calendar dateProp2 = getCalendar("UTC", 1253410638984L);
+    final Design design = context.create().design("/etc/designs/test", "Test",
+        "a", true,
+        "b", 10L,
+        "c", "test",
+        "d", 100,
+        "e", dateProp,
+        "f", dateProp2);
+    final JsonObjectBuilder expectedJson = Json
+        .createObjectBuilder()
+        .add("a", true)
+        .add("b", 10)
+        .add("c", "test")
+        .add("d", 100)
+        .add("e", "Sat Nov 02 2013 23:07:19 GMT+0100")
+        .add("f", "Sun Sep 20 2009 01:37:18 GMT+0000")
+        .add("jcr:title", "Test");
+    if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
+      expectedJson
+          .add("jcr:created", "<value-ignored>")
+          .add("jcr:createdBy", "admin");
     }
+    JSONAssert.assertEquals(expectedJson.build().toString(), design.getJSON(),
+        new IgnoringFieldsComparator(JSONCompareMode.STRICT, "jcr:created"));
+  }
 
-    @Test
-    public void design() {
-        final Design design = context.create().design("/etc/designs/test");
-        assertEquals("test", design.getId());
-        assertEquals("/etc/designs/test", design.getPath());
-    }
-
-    @Test
-    public void getJSON() throws JSONException {
-        final Calendar dateProp = getCalendar("Europe/Amsterdam", 1383430039843L);
-        final Calendar dateProp2 = getCalendar("UTC", 1253410638984L);
-        final Design design = context.create().design("/etc/designs/test", "Test",
-                "a", true,
-                "b", 10L,
-                "c", "test",
-                "d", 100,
-                "e", dateProp,
-                "f", dateProp2);
-        final JsonObjectBuilder expectedJson = Json
-                .createObjectBuilder()
-                .add("a", true)
-                .add("b", 10)
-                .add("c", "test")
-                .add("d", 100)
-                .add("e", "Sat Nov 02 2013 23:07:19 GMT+0100")
-                .add("f", "Sun Sep 20 2009 01:37:18 GMT+0000")
-                .add("jcr:title", "Test");
-        if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
-            expectedJson
-                    .add("jcr:created", "<value-ignored>")
-                    .add("jcr:createdBy", "admin");
-        }
-        JSONAssert.assertEquals(expectedJson.build().toString(), design.getJSON(),
-                new IgnoringFieldsComparator(JSONCompareMode.STRICT, "jcr:created"));
-    }
-
-    private static class IgnoringFieldsComparator extends DefaultComparator {
-        @NotNull
-        private final Set<String> ignoredFields;
-
-        IgnoringFieldsComparator(@NotNull final JSONCompareMode mode, @NotNull final String... ignoredFields) {
-            super(mode);
-            this.ignoredFields = Set.of(ignoredFields);
-        }
-
-        @Override
-        public void compareValues(final String prefix, final Object expectedValue, final Object actualValue, final JSONCompareResult result) throws JSONException {
-            if (!ignoredFields.contains(prefix)) {
-                super.compareValues(prefix, expectedValue, actualValue, result);
-            }
-        }
-    }
+  private static class IgnoringFieldsComparator extends DefaultComparator {
 
     @NotNull
-    private static Calendar getCalendar(@NotNull final String zoneId, final long millis) {
-        final Calendar c1 = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
-        c1.setTimeInMillis(millis);
-        return c1;
+    private final Set<String> ignoredFields;
+
+    IgnoringFieldsComparator(@NotNull final JSONCompareMode mode, @NotNull final String... ignoredFields) {
+      super(mode);
+      this.ignoredFields = Set.of(ignoredFields);
     }
+
+    @Override
+    public void compareValues(final String prefix, final Object expectedValue, final Object actualValue, final JSONCompareResult result) throws JSONException {
+      if (!ignoredFields.contains(prefix)) {
+        super.compareValues(prefix, expectedValue, actualValue, result);
+      }
+    }
+  }
+
+  @NotNull
+  private static Calendar getCalendar(@NotNull final String zoneId, final long millis) {
+    final Calendar c1 = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
+    c1.setTimeInMillis(millis);
+    return c1;
+  }
+
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignerTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignerTest.java
@@ -19,7 +19,8 @@
  */
 package io.wcm.testing.mock.aem;
 
-import static io.wcm.testing.mock.aem.MockDesigner.*;
+import static io.wcm.testing.mock.aem.MockDesigner.LEGACY_DEFAULT_DESIGN_PATH;
+import static io.wcm.testing.mock.aem.MockDesigner.LIBS_DEFAULT_DESIGN_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -27,8 +28,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import com.day.cq.wcm.api.NameConstants;
-import com.day.cq.wcm.api.designer.Design;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -36,7 +35,9 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.designer.Design;
 
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.junit.AemContext;
@@ -126,7 +127,7 @@ public class MockDesignerTest {
   private static Matcher<Design> designWithPath(@NotNull final String expectedPath) {
     return new TypeSafeMatcher<>() {
       @Override
-      protected boolean matchesSafely(@NotNull final Design design) {
+      protected boolean matchesSafely(Design design) {
         return expectedPath.equals(design.getPath());
       }
 

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignerTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignerTest.java
@@ -19,16 +19,24 @@
  */
 package io.wcm.testing.mock.aem;
 
+import static io.wcm.testing.mock.aem.MockDesigner.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.designer.Design;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 
 import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.designer.Designer;
 
 import io.wcm.testing.mock.aem.context.TestAemContext;
 import io.wcm.testing.mock.aem.junit.AemContext;
@@ -38,43 +46,103 @@ public class MockDesignerTest {
   @Rule
   public AemContext context = TestAemContext.newAemContext();
 
-  private Designer underTest;
-  private Page page;
-
-  @Before
-  public void setUp() {
-    underTest = context.resourceResolver().adaptTo(Designer.class);
-    page = context.create().page("/content/page1");
+  @Test
+  public void testGetDesignPathForNullPage() {
+    assertNull(context.designer().getDesignPath(null));
   }
 
   @Test
-  public void testGetDesignPath() {
-    assertNull(underTest.getDesignPath(page));
+  public void testGetDesignPathForNonExistingDesign() {
+    final Page page = context.create().page("/content/page1");
+    assertEquals(LIBS_DEFAULT_DESIGN_PATH, context.designer().getDesignPath(page));
+  }
+
+  @Test
+  public void testGetDesignPathForNonExistingDesignLegacy() {
+    context.create().design(LEGACY_DEFAULT_DESIGN_PATH);
+    final Page page = context.create().page("/content/page1");
+    assertEquals(LEGACY_DEFAULT_DESIGN_PATH, context.designer().getDesignPath(page));
+  }
+
+  @Test
+  public void testGetDesignPageNullPage() {
+    assertNull(context.designer().getDesign((Page)null));
+  }
+
+  @Test
+  public void testGetDesignPageWithoutDesign() {
+    final Page page = context.create().page("/content/page1");
+    assertThat(context.designer().getDesign(page), is(designWithPath(LIBS_DEFAULT_DESIGN_PATH)));
   }
 
   @Test
   public void testGetDesignPage() {
-    assertNotNull(underTest.getDesign(page));
+    final Design design = context.create().design("/etc/designs/test");
+    final Page page = context.create().page("/content/page1", null,
+            NameConstants.PN_DESIGN_PATH, design.getPath());
+    assertThat(context.designer().getDesign(page), is(designWithPath(design.getPath())));
   }
 
   @Test
   public void testHasDesign() {
-    assertTrue(underTest.hasDesign("/any/id"));
+    assertFalse(context.designer().hasDesign("/any/id"));
   }
 
   @Test
   public void testGetDesignString() {
-    assertNotNull(underTest.getDesign("/any/id"));
+    assertThat(context.designer().getDesign("/any/id"), is(designWithPath(LIBS_DEFAULT_DESIGN_PATH)));
   }
 
   @Test
   public void testGetStyleResource() {
-    assertNotNull(underTest.getStyle(page.getContentResource()));
+    final Page page = context.create().page("/content/page1");
+    assertNotNull(context.designer().getStyle(page.getContentResource()));
   }
 
   @Test
   public void testGetStyleResourceString() {
-    assertNotNull(underTest.getStyle(page.getContentResource(), "anyCell"));
+    final Page page = context.create().page("/content/page1");
+    assertNotNull(context.designer().getStyle(page.getContentResource(), "anyCell"));
   }
 
+  @Test
+  public void testGetDefaultDesignNonExisting() {
+      assertThat(context.designer().getDefaultDesign(), designWithPath(LIBS_DEFAULT_DESIGN_PATH));
+  }
+
+  @Test
+  public void testGetDefaultDesign() {
+    context.create().design(LIBS_DEFAULT_DESIGN_PATH);
+    assertThat(context.designer().getDefaultDesign(), designWithPath(LIBS_DEFAULT_DESIGN_PATH));
+  }
+
+  @Test
+  public void testGetDefaultDesignLegacy() {
+    context.create().design(LEGACY_DEFAULT_DESIGN_PATH);
+    assertThat(context.designer().getDefaultDesign(), designWithPath(LEGACY_DEFAULT_DESIGN_PATH));
+  }
+
+  @NotNull
+  private static Matcher<Design> designWithPath(@NotNull final String expectedPath) {
+    return new TypeSafeMatcher<>() {
+      @Override
+      protected boolean matchesSafely(@NotNull final Design design) {
+        return expectedPath.equals(design.getPath());
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("Design with path ")
+          .appendValue(expectedPath);
+      }
+
+      @Override
+      protected void describeMismatchSafely(Design item, Description mismatchDescription) {
+        mismatchDescription
+          .appendText("Design with path ")
+          .appendValue(item.getPath());
+      }
+    };
+  }
 }

--- a/core/src/test/java/io/wcm/testing/mock/aem/builder/ContentBuilderTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/builder/ContentBuilderTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Map;
 
+import com.day.cq.wcm.api.designer.Design;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
 import org.junit.Rule;
@@ -358,6 +359,16 @@ public class ContentBuilderTest {
     assertNotNull(resource2);
     assertEquals(contentRoot + "/test1/page1/jcr:content/test2/test21", resource2.getPath());
     assertEquals("value1", resource2.getValueMap().get("prop1", String.class));
+  }
+
+  @Test
+  public void testDesign() {
+    final Design design = context.create().design("/apps/my-design", "My design",
+            "test", true);
+    assertNotNull(design);
+    assertEquals("/apps/my-design", design.getPath());
+    assertEquals("My design", design.getContentResource().getValueMap().get("jcr:title", String.class));
+    assertTrue(design.getContentResource().getValueMap().get("test", false));
   }
 
   @SuppressWarnings("null")


### PR DESCRIPTION
* MockDesigner/MockDesign: Support the creation of designs in ContentBuilder.
* MockDesigner: Add designer-method in AemContextImpl.
* MockStyle: Simplify implementation by using ValueMapDecorator.
* MockDesigner: Implement getting designs and fallbacks to the default designs. Support legacy designs.
* MockDesign: Implement MockDesign#getContentResource + MockDesign#getId() + MockDesign#getJSON.
* MockAemAdapterFactory: Support getting a Design from a Resource. Improve unit test coverage.