### PR TITLE
#90 Support sub-nodes again in Design#getJSON

### DIFF
--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.io.Writer;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.jsp.PageContext;
@@ -127,19 +127,9 @@ class MockDesign implements Design {
     final Resource contentResource = this.getContentResource();
     if (contentResource != null) {
       try {
-        final Map<String, Object> filteredMap = contentResource.getValueMap().entrySet().stream()
-            .filter(entry -> !JSON_EXCLUDE_PROPERTY_NAMES.contains(entry.getKey()))
-            .map(entry -> {
-              if (entry.getValue() instanceof Calendar) {
-                Calendar calendar = (Calendar)entry.getValue();
-                return Map.entry(entry.getKey(), (Object)JSON_DATE_FORMAT.format(calendar.toInstant().atZone(calendar.getTimeZone().toZoneId())));
-              }
-              else {
-                return entry;
-              }
-            })
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        return JSON_MAPPER.writeValueAsString(filteredMap);
+        final Map<String, Object> map = new HashMap<>();
+        addSafePropertiesToJson(map, contentResource);
+        return JSON_MAPPER.writeValueAsString(map);
       }
       catch (JsonProcessingException ex) {
         throw new RuntimeException("Unable to serialize design content resource properties to JSON", ex);
@@ -203,4 +193,22 @@ class MockDesign implements Design {
     throw new UnsupportedOperationException();
   }
 
+  private void addSafePropertiesToJson(@NotNull final Map<String, Object> map,
+                                       @NotNull final Resource contentResource) {
+    contentResource.getValueMap().entrySet().stream()
+        .filter(entry -> !JSON_EXCLUDE_PROPERTY_NAMES.contains(entry.getKey()))
+        .forEach(entry -> {
+          if (entry.getValue() instanceof Calendar) {
+            Calendar calendar = (Calendar) entry.getValue();
+            map.put(entry.getKey(), JSON_DATE_FORMAT.format(calendar.toInstant().atZone(calendar.getTimeZone().toZoneId())));
+          } else {
+            map.put(entry.getKey(), entry.getValue());
+          }
+        });
+    contentResource.getChildren().forEach(child -> {
+      final Map<String, Object> subMap = new HashMap<>();
+      addSafePropertiesToJson(subMap, child);
+      map.put(child.getName(), subMap);
+    });
+  }
 }

--- a/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/MockDesign.java
@@ -199,7 +199,7 @@ class MockDesign implements Design {
         .filter(entry -> !JSON_EXCLUDE_PROPERTY_NAMES.contains(entry.getKey()))
         .forEach(entry -> {
           if (entry.getValue() instanceof Calendar) {
-            Calendar calendar = (Calendar) entry.getValue();
+            Calendar calendar = (Calendar)entry.getValue();
             map.put(entry.getKey(), JSON_DATE_FORMAT.format(calendar.toInstant().atZone(calendar.getTimeZone().toZoneId())));
           } else {
             map.put(entry.getKey(), entry.getValue());

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
@@ -658,6 +658,42 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
   }
 
   /**
+   * Create child resource below the design's <code>jcr:content</code> resource. If parent resource(s) do not exist they
+   * are created automatically using <code>nt:unstructured</code> nodes.
+   * @param design Design to create resource in
+   * @param name Child resource name
+   * @return Resource object
+   */
+  public @NotNull Resource resource(@NotNull Design design, @NotNull String name) {
+    return resource(design, name, ValueMap.EMPTY);
+  }
+
+  /**
+   * Create child resource below the design's <code>jcr:content</code> resource. If parent resource(s) do not exist they
+   * are created automatically using <code>nt:unstructured</code> nodes.
+   * @param design Design to create resource in
+   * @param name Child resource name
+   * @param properties Properties for resource.
+   * @return Resource object
+   */
+  public @NotNull Resource resource(@NotNull Design design, @NotNull String name, @NotNull Map<String, Object> properties) {
+    String path = design.getContentResource().getPath() + "/" + StringUtils.stripStart(name, "/");
+    return resource(path, properties);
+  }
+
+  /**
+   * Create child resource below the design's <code>jcr:content</code> resource. If parent resource(s) do not exist they
+   * are created automatically using <code>nt:unstructured</code> nodes.
+   * @param design Design to create resource in
+   * @param name Child resource name
+   * @param properties Properties for resource.
+   * @return Resource object
+   */
+  public @NotNull Resource resource(@NotNull Design design, @NotNull String name, @NotNull Object @NotNull... properties) {
+    return resource(design, name, MapUtil.toMap(properties));
+  }
+
+  /**
    * Create a design page.
    * @param path Path of the design resource
    * @param properties Properties for the design resource

--- a/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
+++ b/core/src/main/java/io/wcm/testing/mock/aem/builder/ContentBuilder.java
@@ -662,17 +662,6 @@ public final class ContentBuilder extends org.apache.sling.testing.mock.sling.bu
    * are created automatically using <code>nt:unstructured</code> nodes.
    * @param design Design to create resource in
    * @param name Child resource name
-   * @return Resource object
-   */
-  public @NotNull Resource resource(@NotNull Design design, @NotNull String name) {
-    return resource(design, name, ValueMap.EMPTY);
-  }
-
-  /**
-   * Create child resource below the design's <code>jcr:content</code> resource. If parent resource(s) do not exist they
-   * are created automatically using <code>nt:unstructured</code> nodes.
-   * @param design Design to create resource in
-   * @param name Child resource name
    * @param properties Properties for resource.
    * @return Resource object
    */

--- a/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
+++ b/core/src/test/java/io/wcm/testing/mock/aem/MockDesignTest.java
@@ -76,19 +76,25 @@ public class MockDesignTest {
         "d", 100,
         "e", dateProp,
         "f", dateProp2);
+    context.create().resource(design, "test", "a", false, "b", 440);
 
-    final Map<String,Object> expectedData = new HashMap<>();
-    expectedData.put("a", true);
-    expectedData.put("b", 10);
-    expectedData.put("c", "test");
-    expectedData.put("d", 100);
-    expectedData.put("e", "Sat Nov 02 2013 23:07:19 GMT+0100");
-    expectedData.put("f", "Sun Sep 20 2009 01:37:18 GMT+0000");
-    expectedData.put("jcr:title", "Test");
+    final Map<String, Object> expectedData = new HashMap<>();
     if (context.resourceResolverType() == ResourceResolverType.JCR_OAK) {
       expectedData.put("jcr:created", "<value-ignored>");
       expectedData.put("jcr:createdBy", "admin");
     }
+    expectedData.putAll(Map.of(
+        "a", true,
+        "b", 10,
+        "c", "test",
+        "d", 100,
+        "e", "Sat Nov 02 2013 23:07:19 GMT+0100",
+        "f", "Sun Sep 20 2009 01:37:18 GMT+0000",
+        "jcr:title", "Test",
+        "test", Map.of(
+            "a", false,
+            "b", 440
+    )));
     JSONAssert.assertEquals(JSON_MAPPER.writeValueAsString(expectedData), design.getJSON(),
         new IgnoringFieldsComparator(JSONCompareMode.STRICT, "jcr:created"));
   }


### PR DESCRIPTION
Support sub-nodes again in Design#getJSON.
Make sure the feature does not get removed again (test coverage).
Add helper methods in ContentBuilder to create resources in designs.

Fixes #90 